### PR TITLE
Adding Migration Guide 

### DIFF
--- a/docs/MigrationGuide.md
+++ b/docs/MigrationGuide.md
@@ -1,0 +1,68 @@
+Migration Guide for Python language bindings for preCICE version 2.0
+------------------------------------
+
+# Steps to move from old Python API to the new API
+
+## 1. Solver Interface initialization call is changed
+
+The solver interface initialization call now initializes the solver and also configures it using the configuration
+file provided by the user.
+The previous calls were:
+```
+interface = precice.Interface(solverName, processRank, processSize)
+interface.configure(configFileName)
+```
+The calls have now been combined to:
+```
+interface = precice.Interface(solverName, configFileName, processRank, processSize)
+```
+
+## 2. Array updation is done by returning the appropriate array rather than implicit updating of function argument
+
+In the old adapter the array of values which was generated or updated by a API function was passed as a function argument.
+This is now changed and the API function returns the appropriate which is intended to be computed or updated.
+For example let us consider the interface function `set_mesh_vertices`:
+The old use of this function to generate coupling mesh vertices (vertexIDs) was:
+```
+interface.set_mesh_vertices(meshID, numberofVertices, grid, vertexIDs)
+```
+This has now been changed to:
+```
+vertexIDs = interface.set_mesh_vertices(meshID, grid)
+```
+The same change has been done in API calls to read data from preCICE. 
+The previous call to read data was:
+```
+interface.read_block_scalar_data(readDataID, readDataSize, vertexIDs, readDataArray)
+```
+The new call is:
+```
+readDataArray = interface.read_block_scalar_data(readDataID, vertexIDs)
+```
+
+## 3. Reduced number of inputs arguments for API calls
+
+Unlike the old bindings, API calls now do not need the array size to be passed as an argument anymore. 
+For example let us consider the call `set_mesh_vertices`.
+The previous call was:
+```
+interface.set_mesh_vertices(meshID, numberofVertices, grid, vertexIDs)
+```
+This has now been changed to:
+```
+vertexIDs = interface.set_mesh_vertices(meshID, grid)
+```
+The same change can be seen for all other calls which work with arrays of data. For example the call
+`write_block_vector_data` is changed as follows:
+The previous call was:
+```
+interface.write_block_vector_data(writeDataID, writeDataSize, vertexIDs, writeDataArray)
+```
+The new function call is:
+```
+interface.write_block_vector_data(writeDataID, vertexIDs, writeDataArray)
+```
+Analogously this same change is done for function call `write_block_scalar_data` and all other relevant functions.
+
+## 4. 
+

--- a/docs/MigrationGuide.md
+++ b/docs/MigrationGuide.md
@@ -5,87 +5,65 @@ Migration Guide for Python language bindings for preCICE version 2.0
 
 ### 1. Python language bindings moved to a new repository in the preCICE Project
 
-Previously the Python language bindings were part of the main *preCICE* repository. The bindings have now been
-moved to an [independent repository](https://github.com/precice/python-bindings)
+Previously, the Python language bindings were part of the repository [`precice/precice`](). The bindings have now been
+moved to the independent repository [`precice/python-bindings`](https://github.com/precice/python-bindings).
 
-The installation procedure is same as mentioned in the [README](https://github.com/precice/python-bindings/blob/develop/README.md)
+The installation procedure is the same as before. Please refer to the [README](https://github.com/precice/python-bindings/blob/develop/README.md).
 
-### 2. Solver Interface initialization call is changed
+### 2. New initialization of `Interface`
 
-The solver interface initialization call now initializes the solver and also configures it using the configuration
+The initialization of the `Interface` object now initializes the solver and also configures it using the configuration
 file provided by the user.
-The old API function calls were:
+
+**Old:** Before preCICE Version 2 you had to call:
 ```
 interface = precice.Interface(solverName, processRank, processSize)
 interface.configure(configFileName)
 ```
-The calls have now been combined and the **new** function call is:
+
+**New:** The two commands have now been combined into a single one:
 ```
 interface = precice.Interface(solverName, configFileName, processRank, processSize)
 ```
 
-### 3. Array updation is done by returning the updated array
+### 3. Reduced number of inputs arguments for API calls
 
-In the old adapter the array of values which was generated or updated by a API function was passed as a function argument.
-This is now changed and the API function returns the appropriate which is intended to be computed or updated.
-For example let us consider the interface function `set_mesh_vertices`:
-The old API function to generate coupling mesh vertices (vertexIDs) was:
-```
-interface.set_mesh_vertices(meshID, numberofVertices, grid, vertexIDs)
-```
-The **new** function call is:
-```
-vertexIDs = interface.set_mesh_vertices(meshID, grid)
-```
-The same change has been done in API calls to read data from preCICE. 
-The old API function call was:
-```
-interface.read_block_scalar_data(readDataID, readDataSize, vertexIDs, readDataArray)
-```
-The **new** function call is:
-```
-readDataArray = interface.read_block_scalar_data(readDataID, vertexIDs)
-```
+Unlike the old bindings, API calls now do not need the array size to be passed as an argument anymore. The bindings directly take the size of the array that you are providing.
 
-### 4. Reduced number of inputs arguments for API calls
+For example let us consider the call `write_block_vector_data`:
 
-Unlike the old bindings, API calls now do not need the array size to be passed as an argument anymore. 
-For example let us consider the call `set_mesh_vertices`.
-The old API function call was:
-```
-interface.set_mesh_vertices(meshID, numberofVertices, grid, vertexIDs)
-```
-The **new** function call is:
-```
-vertexIDs = interface.set_mesh_vertices(meshID, grid)
-```
-The same change can be seen for all other calls which work with arrays of data. For example the call
-`write_block_vector_data` is changed as follows:
-The old API function call was:
+**Old:** The previous call was:
 ```
 interface.write_block_vector_data(writeDataID, writeDataSize, vertexIDs, writeDataArray)
 ```
-The **new** function call is:
+
+**New:** The new function call is:
 ```
 interface.write_block_vector_data(writeDataID, vertexIDs, writeDataArray)
 ```
-Analogously this same change is done for function call `write_block_scalar_data` and all other relevant functions.
+The same change is applied for all other calls which work with arrays of data.
 
-### 5. Formatting of Numpy arrays is changed
+### 4. API functions use a return value, if appropriate
 
-In the earlier bindings for a simulation in `D` dimensions, the Numpy array representing the coupling mesh having 
-`N` vertices was structed as `grid = np.zeros([D, N+1])`.
-The new structure now used is: `grid = np.zeros([N+1, D])`
+In older versions of the python bindings arrays were modified by the API in a call-by-reference fashion. This means a pointer to the array was passed to the API as a function argument. This approach was changed and the API functions now directly return the an array.
 
-In the earlier bindings it was the users responsibility to flatten a multi-dimensional array before passing it to
-a API call. This is not not necessary as the API calls take care of this internally. For example let us consider
-the call `set_mesh_vertices`:
-The old API function call was:
+For example let us consider the interface function `set_mesh_vertices`. `set_mesh_vertices` is used to register vertices for a mesh and it returns an array of `vertexIDs`.
+
+**Old:** The old signature of this function was:
 ```
-interface.set_mesh_vertices(meshID, meshSize, grid.flatten('F'), vertexIDs)
+vertexIDs = np.zeros(numberofVertices)
+interface.set_mesh_vertices(meshID, numberofVertices, grid, vertexIDs)
 ```
-The **new** function call is:
+Note that `vertexIDs` is passed as an argument to the function.
+
+**New:** This has now been changed to:
 ```
 vertexIDs = interface.set_mesh_vertices(meshID, grid)
 ```
+Here, `vertexIDs` is directly returned by `set_mesh_vertices`.
 
+The same change has been applied to the functions `read_block_scalar_data` and `read_block_vector_data`.
+
+### 5. Consequently use numpy arrays as data structure
+
+We consequently use numpy arrays for storing array data (multidimensional lists are still accepted). As an example, the `N` coupling mesh vertices of a mesh in `D` dimensions are represented as `grid = np.zeros([N, D])`. Previous versions of the bindings used either `grid = np.zeros([N, D])` (transposed version) or `grid = np.zeros(N*D)`. The same rule applies for data written and read in `write_block_vector_data` and `read_block_vector_data`.

--- a/docs/MigrationGuide.md
+++ b/docs/MigrationGuide.md
@@ -5,7 +5,7 @@ Migration Guide for Python language bindings for preCICE version 2.0
 
 ### 1. Python language bindings moved to a new repository in the preCICE Project
 
-Previously the Python language bindings were part of the main preCICE repository. The bindings have now been
+Previously the Python language bindings were part of the main *preCICE* repository. The bindings have now been
 moved to an [independent repository](https://github.com/precice/python-bindings)
 
 The installation procedure is same as mentioned in the [README](https://github.com/precice/python-bindings/blob/develop/README.md)
@@ -14,12 +14,12 @@ The installation procedure is same as mentioned in the [README](https://github.c
 
 The solver interface initialization call now initializes the solver and also configures it using the configuration
 file provided by the user.
-The previous calls were:
+The old API function calls were:
 ```
 interface = precice.Interface(solverName, processRank, processSize)
 interface.configure(configFileName)
 ```
-The calls have now been combined to one call:
+The calls have now been combined and the **new** function call is:
 ```
 interface = precice.Interface(solverName, configFileName, processRank, processSize)
 ```
@@ -29,20 +29,20 @@ interface = precice.Interface(solverName, configFileName, processRank, processSi
 In the old adapter the array of values which was generated or updated by a API function was passed as a function argument.
 This is now changed and the API function returns the appropriate which is intended to be computed or updated.
 For example let us consider the interface function `set_mesh_vertices`:
-The old use of this function to generate coupling mesh vertices (vertexIDs) was:
+The old API function to generate coupling mesh vertices (vertexIDs) was:
 ```
 interface.set_mesh_vertices(meshID, numberofVertices, grid, vertexIDs)
 ```
-This has now been changed to:
+The **new** function call is:
 ```
 vertexIDs = interface.set_mesh_vertices(meshID, grid)
 ```
 The same change has been done in API calls to read data from preCICE. 
-The previous call to read data was:
+The old API function call was:
 ```
 interface.read_block_scalar_data(readDataID, readDataSize, vertexIDs, readDataArray)
 ```
-The new call is:
+The **new** function call is:
 ```
 readDataArray = interface.read_block_scalar_data(readDataID, vertexIDs)
 ```
@@ -51,21 +51,21 @@ readDataArray = interface.read_block_scalar_data(readDataID, vertexIDs)
 
 Unlike the old bindings, API calls now do not need the array size to be passed as an argument anymore. 
 For example let us consider the call `set_mesh_vertices`.
-The previous call was:
+The old API function call was:
 ```
 interface.set_mesh_vertices(meshID, numberofVertices, grid, vertexIDs)
 ```
-This has now been changed to:
+The **new** function call is:
 ```
 vertexIDs = interface.set_mesh_vertices(meshID, grid)
 ```
 The same change can be seen for all other calls which work with arrays of data. For example the call
 `write_block_vector_data` is changed as follows:
-The previous call was:
+The old API function call was:
 ```
 interface.write_block_vector_data(writeDataID, writeDataSize, vertexIDs, writeDataArray)
 ```
-The new function call is:
+The **new** function call is:
 ```
 interface.write_block_vector_data(writeDataID, vertexIDs, writeDataArray)
 ```
@@ -80,11 +80,11 @@ The new structure now used is: `grid = np.zeros([N+1, D])`
 In the earlier bindings it was the users responsibility to flatten a multi-dimensional array before passing it to
 a API call. This is not not necessary as the API calls take care of this internally. For example let us consider
 the call `set_mesh_vertices`:
-The old call was:
+The old API function call was:
 ```
 interface.set_mesh_vertices(meshID, meshSize, grid.flatten('F'), vertexIDs)
 ```
-This call is now modified to:
+The **new** function call is:
 ```
 vertexIDs = interface.set_mesh_vertices(meshID, grid)
 ```

--- a/docs/MigrationGuide.md
+++ b/docs/MigrationGuide.md
@@ -5,8 +5,8 @@ Migration Guide for Python language bindings for preCICE version 2.0
 
 ### 1. Python language bindings moved to a new repository in the preCICE Project
 
-Previously, the Python language bindings were part of the repository [`precice/precice`](). The bindings have now been
-moved to the independent repository [`precice/python-bindings`](https://github.com/precice/python-bindings).
+Previously, the Python language bindings were part of the repository [`precice/precice`](https://github.com/precice/precice). 
+The bindings have now been moved to the independent repository [`precice/python-bindings`](https://github.com/precice/python-bindings).
 
 The installation procedure is the same as before. Please refer to the [README](https://github.com/precice/python-bindings/blob/develop/README.md).
 

--- a/docs/MigrationGuide.md
+++ b/docs/MigrationGuide.md
@@ -3,7 +3,14 @@ Migration Guide for Python language bindings for preCICE version 2.0
 
 # Steps to move from old Python API to the new API
 
-## 1. Solver Interface initialization call is changed
+### 1. Python language bindings moved to a new repository in the preCICE Project
+
+Previously the Python language bindings were part of the main preCICE repository. The bindings have now been
+moved to an [independent repository](https://github.com/precice/python-bindings)
+
+The installation procedure is same as mentioned in the [README](https://github.com/precice/python-bindings/blob/develop/README.md)
+
+### 2. Solver Interface initialization call is changed
 
 The solver interface initialization call now initializes the solver and also configures it using the configuration
 file provided by the user.
@@ -12,12 +19,12 @@ The previous calls were:
 interface = precice.Interface(solverName, processRank, processSize)
 interface.configure(configFileName)
 ```
-The calls have now been combined to:
+The calls have now been combined to one call:
 ```
 interface = precice.Interface(solverName, configFileName, processRank, processSize)
 ```
 
-## 2. Array updation is done by returning the appropriate array rather than implicit updating of function argument
+### 3. Array updation is done by returning the updated array
 
 In the old adapter the array of values which was generated or updated by a API function was passed as a function argument.
 This is now changed and the API function returns the appropriate which is intended to be computed or updated.
@@ -40,7 +47,7 @@ The new call is:
 readDataArray = interface.read_block_scalar_data(readDataID, vertexIDs)
 ```
 
-## 3. Reduced number of inputs arguments for API calls
+### 4. Reduced number of inputs arguments for API calls
 
 Unlike the old bindings, API calls now do not need the array size to be passed as an argument anymore. 
 For example let us consider the call `set_mesh_vertices`.
@@ -64,5 +71,21 @@ interface.write_block_vector_data(writeDataID, vertexIDs, writeDataArray)
 ```
 Analogously this same change is done for function call `write_block_scalar_data` and all other relevant functions.
 
-## 4. 
+### 5. Formatting of Numpy arrays is changed
+
+In the earlier bindings for a simulation in `D` dimensions, the Numpy array representing the coupling mesh having 
+`N` vertices was structed as `grid = np.zeros([D, N+1])`.
+The new structure now used is: `grid = np.zeros([N+1, D])`
+
+In the earlier bindings it was the users responsibility to flatten a multi-dimensional array before passing it to
+a API call. This is not not necessary as the API calls take care of this internally. For example let us consider
+the call `set_mesh_vertices`:
+The old call was:
+```
+interface.set_mesh_vertices(meshID, meshSize, grid.flatten('F'), vertexIDs)
+```
+This call is now modified to:
+```
+vertexIDs = interface.set_mesh_vertices(meshID, grid)
+```
 


### PR DESCRIPTION
This PR adds a migration guide in the `docs/` folder to help users who were using the old python bindings and are now moving to the new python bindings. Closes https://github.com/precice/python-bindings/issues/27