### PR TITLE
Implement versioning strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Python language bindings for the C++ library preCICE
     <img src="https://travis-ci.org/precice/python-bindings.svg?branch=develop" alt="Build status">
 </a>
 
+This package provides python language bindings for the C++ library [preCICE](https://github.com/precice/precice). Note that the first three digits of the version number of the bindings indicate the preCICE version that the bindings support. The last digit represents the version of the bindings. Example: `v2.0.0.1` of the bindings represents version `1` of the bindings which is compatible with preCICE `v2.0.0`.
+
 # Installing the package
 
 We recommend [using pip3](https://github.com/precice/precice/blob/develop/src/precice/bindings/python/README.md#using-pip3) for the sake of simplicity.

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ APPNAME = "pyprecice"
 precice_version = version.Version("2.0.0")  # todo: should be replaced with precice.get_version(), if possible or we should add an assertion that makes sure that the version of preCICE is actually supported
 # this version number may be increased, if changes for the bindings are required
 bindings_version = version.Version("1")
-APPVERSION = version.Version(str(precice_version) + "." + str(bindings_subversion))
+APPVERSION = version.Version(str(precice_version) + "." + str(bindings_version))
 
 PYTHON_BINDINGS_PATH = os.path.dirname(os.path.abspath(__file__))
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,11 @@ assert(version.parse(pip.__version__) >= version.parse("10.0.1"))  # minimum ver
 
 # name of Interfacing API
 APPNAME = "pyprecice"
-APPVERSION = "2.0.0a1"  # todo: should be replaced with precice.get_version() as soon as it exists , see https://github.com/precice/precice/issues/261
+# this version should be in sync with the latest supported preCICE version
+precice_version = version.Version("2.0.0")  # todo: should be replaced with precice.get_version(), if possible or we should add an assertion that makes sure that the version of preCICE is actually supported
+# this version number may be increased, if changes for the bindings are required
+bindings_version = version.Version("1")
+APPVERSION = version.Version(precice_version+bindings_version)
 
 PYTHON_BINDINGS_PATH = os.path.dirname(os.path.abspath(__file__))
 
@@ -178,7 +182,7 @@ class my_test(test, object):
 # build precice.so python extension to be added to "PYTHONPATH" later
 setup(
     name=APPNAME,
-    version=APPVERSION,
+    version=str(APPVERSION),
     description='Python language bindings for preCICE coupling library',
     url='https://github.com/precice/python-bindings',
     author='the preCICE developers',

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ APPNAME = "pyprecice"
 precice_version = version.Version("2.0.0")  # todo: should be replaced with precice.get_version(), if possible or we should add an assertion that makes sure that the version of preCICE is actually supported
 # this version number may be increased, if changes for the bindings are required
 bindings_version = version.Version("1")
-APPVERSION = version.Version(precice_version+bindings_version)
+APPVERSION = version.Version(str(precice_version) + "." + str(bindings_subversion))
 
 PYTHON_BINDINGS_PATH = os.path.dirname(os.path.abspath(__file__))
 


### PR DESCRIPTION
We use the current preCICE version and append an independent version number for the python bindings.

Closes #31 