### PR TITLE
Release v2.0.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,25 @@ wget -q https://bootstrap.pypa.io/get-pip.py -O get-pip.py && python3 get-pip.py
 
 Check your version of pip via `pip3 --version`. For version 8.1.1 and 9.0.1 we know that this problem occurs. *Remark:* you get versions 8.1.1 of pip if you use `sudo apt install python3-pip` on Ubuntu 16.04 (pip version 9.0.1 on Ubuntu 18.04)
 
+### Build-time dependencies (Cython, numpy...) defined in `pyproject.toml` are not installed automatically
+
+If you see the following error
+```
+Collecting pyprecice
+  Using cached https://files.pythonhosted.org/packages/a6/fb/66f78168394afa2adca62ecd9079a98e741fbf3c6a96845719641ea27912/pyprecice-2.0.0.1.tar.gz
+    Complete output from command python setup.py egg_info:
+    Traceback (most recent call last):
+      File "<string>", line 1, in <module>
+      File "/tmp/pip-build-ebyoc0sq/pyprecice/setup.py", line 7, in <module>
+        from Cython.Distutils.extension import Extension
+    ModuleNotFoundError: No module named 'Cython'
+```
+your pip might be too old and therefore it does not use the information from `pyproject.toml`. You can update your pip via
+```
+pip3 install --upgrade pip
+```
+then try to install `pyprecice`, again.
+
 ### I'm using preCICE < 2.0.0, but there is no matching version of the bindings. What can I do?
 
 If you want to use the old experimental python bindings (released with preCICE version < 2.0.0), please refer to the documentation of the corresponding preCICE version. 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Python language bindings for the C++ library preCICE
 
 [![Upload Python Package](https://github.com/precice/python-bindings/workflows/Upload%20Python%20Package/badge.svg?branch=master)](https://pypi.org/project/pyprecice/)
 
-This package provides python language bindings for the C++ library [preCICE](https://github.com/precice/precice). Note that the first three digits of the version number of the bindings indicate the preCICE version that the bindings support. The last digit represents the version of the bindings. Example: `v2.0.0.1` of the bindings represents version `1` of the bindings which is compatible with preCICE `v2.0.0`.
+This package provides python language bindings for the C++ library [preCICE](https://github.com/precice/precice). Note that the first three digits of the version number of the bindings indicate the preCICE version that the bindings support. The last digit represents the version of the bindings. Example: `v2.0.0.1` and `v2.0.0.2` of the bindings represent versions `1` and `2` of the bindings that are compatible with preCICE `v2.0.0`.
 
 # Required dependencies
 

--- a/README.md
+++ b/README.md
@@ -11,45 +11,45 @@ This package provides python language bindings for the C++ library [preCICE](htt
 
 # Required dependencies
 
-* **preCICE**: Refer to (the preCICE wiki)[https://github.com/precice/precice/wiki#1-get-precice] for information on installation.
+**preCICE**: Refer to (the preCICE wiki)[https://github.com/precice/precice/wiki#1-get-precice] for information on building and installation.
 
 # Installing the package
 
-We recommend [using pip3](https://github.com/precice/precice/blob/develop/src/precice/bindings/python/README.md#using-pip3) for the sake of simplicity.
+We recommend [using pip3](https://github.com/precice/precice/blob/develop/src/precice/bindings/python/README.md#using-pip3) (version 19.0 or newer) for the sake of simplicity.
 
 ## Using pip3
 
 ### preCICE system installs
 
-For system installs of preCICE, this works out of the box.
+For system installs of preCICE, installation works out of the box. There are different ways how pip can be used to install pyprecice. pip will fetch cython and other build-time dependencies, compile the bindings and finally install the package pyprecice.
 
-You can either install from PyPI
+* (recommended) install pyprecice from PyPI
 
-```
-$ pip3 install --user pyprecice
-```
+  ```
+  $ pip3 install --user pyprecice
+  ```
 
-provide the link to this repository to pip (replace `<branch>` with the branch you want to use, preferably `master` or `develop`)
+* provide the link to this repository to pip (replace `<branch>` with the branch you want to use, preferably `master` or `develop`)
 
-```
-$ pip3 install --user https://github.com/precice/python-bindings/archive/<branch>.zip
-```
+  ```
+  $ pip3 install --user https://github.com/precice/python-bindings/archive/<branch>.zip
+  ```
 
-or, if you cloned this repository, execute the following command from this directory:
+* if you already cloned this repository, execute the following command from this directory:
 
-```
-$ pip3 install --user .
-```
-*note the dot at the end of the line*
-
-This will fetch cython, compile the bindings and finally install the package pyprecice.
+  ```
+  $ pip3 install --user .
+  ```
+  *note the dot at the end of the line*
 
 ### preCICE at custom location (setting PATHS)
 
-If preCICE (the C++ library) was installed in a custom prefix, or not installed at all, you have to extend the following environment variables:
+If preCICE (the C++ library) was installed in a custom prefix, or only built but not installed at all, you have to extend the following environment variables:
 
 - `LIBRARY_PATH`, `LD_LIBRARY_PATH` to the library location, or `$prefix/lib`
 - `CPATH` either to the `src` directory or the `$prefix/include`
+
+The precice wiki provides more informaiton on [linking preCICE](https://github.com/precice/precice/wiki/Linking-to-preCICE).
 
 ## Using setup.py
 
@@ -69,44 +69,45 @@ $ python3 setup.py install --user
 
 ### preCICE at custom location (explicit include path, library path)
 
-1. Install cython via pip3
-```
-$ pip3 install --user cython
-```
+1. Install cython and other dependencies via pip3
+   ```
+   $ pip3 install --user setuptools wheel cython packaging numpy
+   ```
 2. Open terminal in this folder.
 3. Build the bindings
+   ```
+   $ python3 setup.py build_ext --include-dirs=$PRECICE_ROOT/src --library-dirs=$PRECICE_ROOT/build/last
+   ```
 
-```
-$ python3 setup.py build_ext --include-dirs=$PRECICE_ROOT/src --library-dirs=$PRECICE_ROOT/build/last
-```
-
-**Options:**
-- `--include-dirs=`, default: `''` 
-  Path to the headers of preCICE, point to the sources `$PRECICE_ROOT/src`, or the your custom install prefix `$prefix/include`.
+  **Options:**
+  - `--include-dirs=`, default: `''` 
+    Path to the headers of preCICE, point to the sources `$PRECICE_ROOT/src`, or the your custom install prefix `$prefix/include`.
   
-**NOTES:**
-
-- If you build preCICE using CMake, you can pass the path to the CMake binary directory using `--library-dirs`.
-- It is recommended to use preCICE as a shared library here.
+  **NOTES:**
+  
+  - If you have built preCICE using CMake, you can pass the path to the CMake binary directory using `--library-dirs`.
+  - It is recommended to use preCICE as a shared library here.
 
 4. Install the bindings
-```
-$ python3 setup.py install --user
-```
+   ```
+   $ python3 setup.py install --user
+   ```
 
 5. Clean-up _optional_
-```
-$ python3 setup.py clean --all
-```
+   ```
+   $ python3 setup.py clean --all
+   ```
 
 # Test the installation
 
 Update `LD_LIBRARY_PATH` such that python can find `precice.so`
+
 ```
 $ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PRECICE_ROOT/build/last
 ```
 
 Run the following to test the installation:
+
 ```
 $ python3 -c "import precice"
 ```
@@ -114,21 +115,22 @@ $ python3 -c "import precice"
 ## Unit tests
 
 1. Clean-up __mandatory__ (because we must not link against the real `precice.so`, but we use a mocked version)
-```
-$ python3 setup.py clean --all
-```
+   ```
+   $ python3 setup.py clean --all
+   ```
 
 2. Set `CPLUS_INCLUDE_PATH` (we cannot use `build_ext` and the `--include-dirs` option here)
-```
-$ export CPLUS_INCLUDE_PATH=$CPLUS_INCLUDE_PATH:$PRECICE_ROOT/src
-```
+   ```
+   $ export CPLUS_INCLUDE_PATH=$CPLUS_INCLUDE_PATH:$PRECICE_ROOT/src
+   ```
 
 3. Run tests with
-```
-$ python3 setup.py test
-```
+   ```
+   $ python3 setup.py test
+   ```
 
 **NOTE:**
+
 - For an example of how `pyprecice` can be used, refer to the [1D elastic tube example](https://github.com/precice/precice/wiki/1D-elastic-tube-using-the-Python-API).
 
 # Troubleshooting & miscellaneous
@@ -193,7 +195,7 @@ then try to install `pyprecice`, again.
 
 ### I'm using preCICE < 2.0.0, but there is no matching version of the bindings. What can I do?
 
-If you want to use the old experimental python bindings (released with preCICE version < 2.0.0), please refer to the documentation of the corresponding preCICE version. 
+If you want to use the old experimental python bindings (released with preCICE version < 2.0.0), please refer to the corresponding preCICE version. Example: for preCICE v1.6.1 there are three different versions of the python bindings: [`precice_future`](https://github.com/precice/precice/tree/v1.6.1/src/precice/bindings/python_future), [`precice`](https://github.com/precice/precice/tree/v1.6.1/src/precice/bindings/python) and [`PySolverInterface`](https://github.com/precice/precice/tree/v1.6.1/src/precice/bindings/PySolverInterface). Installation instructions can be found in the corresponding `README` files.
 
 ### Installing the python bindings for Python 2.7.17
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Python language bindings for the C++ library preCICE
     <img src="https://travis-ci.org/precice/python-bindings.svg?branch=develop" alt="Build status">
 </a>
 
+[![Upload Python Package](https://github.com/precice/python-bindings/workflows/Upload%20Python%20Package/badge.svg?branch=master)](https://pypi.org/project/pyprecice/)
+
 This package provides python language bindings for the C++ library [preCICE](https://github.com/precice/precice). Note that the first three digits of the version number of the bindings indicate the preCICE version that the bindings support. The last digit represents the version of the bindings. Example: `v2.0.0.1` of the bindings represents version `1` of the bindings which is compatible with preCICE `v2.0.0`.
 
 # Required dependencies

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ APPNAME = "pyprecice"
 # this version should be in sync with the latest supported preCICE version
 precice_version = version.Version("2.0.0")  # todo: should be replaced with precice.get_version(), if possible or we should add an assertion that makes sure that the version of preCICE is actually supported
 # this version number may be increased, if changes for the bindings are required
-bindings_version = version.Version("1")
+bindings_version = version.Version("2rc1")
 APPVERSION = version.Version(str(precice_version) + "." + str(bindings_version))
 
 PYTHON_BINDINGS_PATH = os.path.dirname(os.path.abspath(__file__))
@@ -104,11 +104,19 @@ class my_test(test, object):
         self.distribution.is_test = True       
         super().initialize_options()
 
+        
+this_directory = os.path.abspath(os.path.dirname(__file__))
+with open(os.path.join(this_directory, 'README.md'), encoding='utf-8') as f:
+    long_description = f.read()
+    
+    
 # build precice.so python extension to be added to "PYTHONPATH" later
 setup(
     name=APPNAME,
     version=str(APPVERSION),
     description='Python language bindings for the preCICE coupling library',
+    long_description=long_description,
+    long_description_content_type='text/markdown',
     url='https://github.com/precice/python-bindings',
     author='the preCICE developers',
     author_email='info@precice.org',

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ APPNAME = "pyprecice"
 # this version should be in sync with the latest supported preCICE version
 precice_version = version.Version("2.0.0")  # todo: should be replaced with precice.get_version(), if possible or we should add an assertion that makes sure that the version of preCICE is actually supported
 # this version number may be increased, if changes for the bindings are required
-bindings_version = version.Version("2rc1")
+bindings_version = version.Version("2rc2")
 APPVERSION = version.Version(str(precice_version) + "." + str(bindings_version))
 
 PYTHON_BINDINGS_PATH = os.path.dirname(os.path.abspath(__file__))

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ APPNAME = "pyprecice"
 # this version should be in sync with the latest supported preCICE version
 precice_version = version.Version("2.0.0")  # todo: should be replaced with precice.get_version(), if possible or we should add an assertion that makes sure that the version of preCICE is actually supported
 # this version number may be increased, if changes for the bindings are required
-bindings_version = version.Version("2rc2")
+bindings_version = version.Version("2")
 APPVERSION = version.Version(str(precice_version) + "." + str(bindings_version))
 
 PYTHON_BINDINGS_PATH = os.path.dirname(os.path.abspath(__file__))

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,17 @@
 import os
 import subprocess
-from enum import Enum
+import warnings
+from packaging import version
+import pip
 
+if version.parse(pip.__version__) < version.parse("19.0"):
+    # version 19.0 is required, since we are using pyproject.toml for definition of build-time depdendencies. See https://pip.pypa.io/en/stable/news/#id209
+    warnings.warn("You are using pip version {}. However, pip version > 19.0 is recommended. You can continue with the installation, but installation problems can occour. Please refer to https://github.com/precice/python-bindings#build-time-dependencies-cython-numpy-defined-in-pyprojecttoml-are-not-installed-automatically for help.".format(pip.__version__))
+
+if version.parse(pip.__version__) < version.parse("10.0.1"):        
+    warnings.warn("You are using pip version {}. However, pip version > 10.0.1 is required. If you continue with installation it is likely that you will face an error. See https://github.com/precice/python-bindings#version-of-pip3-is-too-old".format(pip.__version__))
+
+from enum import Enum
 from setuptools import setup
 from setuptools.command.test import test
 from Cython.Distutils.extension import Extension
@@ -9,11 +19,8 @@ from Cython.Distutils.build_ext import new_build_ext as build_ext
 from Cython.Build import cythonize
 from distutils.command.install import install
 from distutils.command.build import build
-from packaging import version
-import pip
 import numpy
 
-assert(version.parse(pip.__version__) >= version.parse("10.0.1"))  # minimum version 10.0.1 is required. See https://github.com/precice/precice/wiki/Non%E2%80%93standard-APIs#python-bindings-version-of-pip3-is-too-old
 
 # name of Interfacing API
 APPNAME = "pyprecice"


### PR DESCRIPTION
If you want to try out the release see https://pypi.org/project/pyprecice/2.0.0.2rc2/.

This release provides documentation fixes and improves the integration into PyPI.

A draft of the release is provided at https://github.com/precice/python-bindings/releases/tag/untagged-c5d23f8074e6a20b86e1.