### PR TITLE
Handle writing of empty arrays to preCICE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## latest
 
-* Bindings are now available via Spack. https://github.com/spack/spack/pull/19558
+* Feature: Bindings are now available via Spack. https://github.com/spack/spack/pull/19558
+* Bugfix: Bindings also support empty read/write data for block read/write operations (like C++ preCICE API). https://github.com/precice/python-bindings/pull/69
 
 ## 2.1.1.1
 

--- a/precice.pyx
+++ b/precice.pyx
@@ -868,8 +868,12 @@ cdef class Interface:
         """
         if not isinstance(values, np.ndarray):
             values = np.asarray(values)
-        size, dimensions = values.shape
-        assert(dimensions == self.get_dimensions())
+        if len(values) > 0:
+            size, dimensions = values.shape
+            assert(dimensions == self.get_dimensions())
+        if len(values) == 0:
+            size = 0
+
         cdef np.ndarray[int, ndim=1] _vertex_ids = np.ascontiguousarray(vertex_ids, dtype=np.int32)
         cdef np.ndarray[double, ndim=1] _values = np.ascontiguousarray(values.flatten(), dtype=np.double)
         assert(size == _vertex_ids.size)
@@ -913,8 +917,10 @@ cdef class Interface:
         """
         if not isinstance(value, np.ndarray):
             value = np.asarray(value)
-        dimensions = value.size
-        assert(dimensions == self.get_dimensions())
+        if len(values) > 0:
+            dimensions = value.size
+            assert(dimensions == self.get_dimensions())
+
         cdef np.ndarray[np.double_t, ndim=1] _value = np.ascontiguousarray(value, dtype=np.double)
         self.thisptr.writeVectorData (data_id, vertex_id, <const double*>_value.data)
 
@@ -948,8 +954,13 @@ cdef class Interface:
         """
         cdef np.ndarray[int, ndim=1] _vertex_ids = np.ascontiguousarray(vertex_ids, dtype=np.int32)
         cdef np.ndarray[double, ndim=1] _values = np.ascontiguousarray(values, dtype=np.double)
-        assert(_values.size == _vertex_ids.size)
-        size = vertex_ids.size
+
+        if len(values) > 0:
+            assert(_values.size == _vertex_ids.size)
+            size = vertex_ids.size
+        if len(values) == 0:
+            size = 0
+
         self.thisptr.writeBlockScalarData (data_id, size, <const int*>_vertex_ids.data, <const double*>_values.data)
 
     def write_scalar_data (self, data_id, vertex_id, double value):

--- a/precice.pyx
+++ b/precice.pyx
@@ -917,7 +917,7 @@ cdef class Interface:
         """
         if not isinstance(value, np.ndarray):
             value = np.asarray(value)
-        if len(values) > 0:
+        if len(value) > 0:
             dimensions = value.size
             assert(dimensions == self.get_dimensions())
 

--- a/precice.pyx
+++ b/precice.pyx
@@ -917,10 +917,9 @@ cdef class Interface:
         """
         if not isinstance(value, np.ndarray):
             value = np.asarray(value)
-        if len(value) > 0:
-            dimensions = value.size
-            assert(dimensions == self.get_dimensions())
-
+        assert(len(value) > 0)
+        dimensions = value.size
+        assert(dimensions == self.get_dimensions())
         cdef np.ndarray[np.double_t, ndim=1] _value = np.ascontiguousarray(value, dtype=np.double)
         self.thisptr.writeVectorData (data_id, vertex_id, <const double*>_value.data)
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ from setuptools.command.test import test
 from Cython.Distutils.extension import Extension
 from Cython.Distutils.build_ext import new_build_ext as build_ext
 from Cython.Build import cythonize
-from distutils.command.build import build
 import numpy
 
 
@@ -78,18 +77,6 @@ class my_build_ext(build_ext, object):
         super().finalize_options()
 
 
-class my_build(build, object):
-    def finalize_options(self):
-        try:
-            self.distribution.is_test
-        except AttributeError:
-            self.distribution.is_test = False
-
-        if not self.distribution.ext_modules:
-            self.distribution.ext_modules = cythonize(get_extensions(self.distribution.is_test), compiler_directives={'language_level': "3"})
-
-        super().finalize_options()
-
 class my_test(test, object):
     def initialize_options(self):
         self.distribution.is_test = True       
@@ -115,8 +102,7 @@ setup(
     python_requires='>=3',
     install_requires=['numpy', 'mpi4py'],  # mpi4py is only needed, if preCICE was compiled with MPI, see https://github.com/precice/python-bindings/issues/8
     cmdclass={'test': my_test,
-              'build_ext': my_build_ext,
-              'build': my_build},
+              'build_ext': my_build_ext},
     package_data={ 'precice': ['*.pxd']},
     include_package_data=True,
     zip_safe=False  #needed because setuptools are used

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ from setuptools.command.test import test
 from Cython.Distutils.extension import Extension
 from Cython.Distutils.build_ext import new_build_ext as build_ext
 from Cython.Build import cythonize
-from distutils.command.install import install
 from distutils.command.build import build
 import numpy
 

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ def get_extensions(is_test):
 
     bindings_sources = [os.path.join(PYTHON_BINDINGS_PATH, "precice") + ".pyx"]
     test_sources = [os.path.join(PYTHON_BINDINGS_PATH, "test", "test_bindings_module" + ".pyx")]
+
     if not is_test:
         link_args.append("-lprecice")
     if is_test:
@@ -66,41 +67,25 @@ def get_extensions(is_test):
     ]
 
 class my_build_ext(build_ext, object):
-    def initialize_options(self):
+    def finalize_options(self):
         try:
             self.distribution.is_test
         except AttributeError:
             self.distribution.is_test = False
-        
-        super().initialize_options()
-        
-    def finalize_options(self):
+
         if not self.distribution.ext_modules:
             self.distribution.ext_modules = cythonize(get_extensions(self.distribution.is_test), compiler_directives={'language_level': "3"})
 
         super().finalize_options()
 
 
-class my_install(install, object):
-    def initialize_options(self):
-        try:
-            self.distribution.is_test
-        except AttributeError:
-            self.distribution.is_test = False
-
-        super().initialize_options()
-
-
 class my_build(build, object):
-    def initialize_options(self):
+    def finalize_options(self):
         try:
             self.distribution.is_test
         except AttributeError:
             self.distribution.is_test = False
 
-        super().initialize_options()
-
-    def finalize_options(self):
         if not self.distribution.ext_modules:
             self.distribution.ext_modules = cythonize(get_extensions(self.distribution.is_test), compiler_directives={'language_level': "3"})
 
@@ -132,8 +117,7 @@ setup(
     install_requires=['numpy', 'mpi4py'],  # mpi4py is only needed, if preCICE was compiled with MPI, see https://github.com/precice/python-bindings/issues/8
     cmdclass={'test': my_test,
               'build_ext': my_build_ext,
-              'build': my_build,
-              'install': my_install},
+              'build': my_build},
     package_data={ 'precice': ['*.pxd']},
     include_package_data=True,
     zip_safe=False  #needed because setuptools are used

--- a/test/test_bindings_module.pyx
+++ b/test/test_bindings_module.pyx
@@ -195,6 +195,13 @@ class TestBindings(TestCase):
         read_data = solver_interface.read_block_scalar_data(1, np.array([1, 2, 3]))
         self.assertTrue(np.array_equal(write_data, read_data))
 
+    def test_read_write_block_scalar_data_empty(self):
+        solver_interface = precice.Interface("test", "dummy.xml", 0, 1)
+        write_data = np.array([])
+        solver_interface.write_block_scalar_data(1, [], write_data)
+        read_data = solver_interface.read_block_scalar_data(1, [])
+        self.assertTrue(len(read_data) == 0)
+
     def test_read_write_block_scalar_data_non_contiguous(self):
         """
         Tests behaviour of solver interface, if a non contiguous array is passed to the interface.
@@ -223,6 +230,13 @@ class TestBindings(TestCase):
         solver_interface.write_block_vector_data(1, np.array([1, 2]), write_data)
         read_data = solver_interface.read_block_vector_data(1, np.array([1, 2]))
         self.assertTrue(np.array_equal(write_data, read_data))
+
+    def test_read_write_block_vector_data_empty(self):
+        solver_interface = precice.Interface("test", "dummy.xml", 0, 1)
+        write_data = np.array([])
+        solver_interface.write_block_vector_data(1, [], write_data)
+        read_data = solver_interface.read_block_vector_data(1, [])
+        self.assertTrue(len(read_data) == 0)
 
     def test_read_write_block_vector_data_list(self):
         solver_interface = precice.Interface("test", "dummy.xml", 0, 1)


### PR DESCRIPTION
In a parallel coupling case, ranks which have no part of the coupling interface will call the write data functionality with empty data structures. The bindings need to handle this as the main preCICE API allows this.