### PR TITLE
Fix bug: It looks like opal_init failed for some reason

### DIFF
--- a/cyprecice/cyprecice.pxd
+++ b/cyprecice/cyprecice.pxd
@@ -6,7 +6,6 @@ The python module precice offers python language bindings to the C++ coupling li
 cimport numpy as np
 cimport cython
 cimport SolverInterface
-from mpi4py import MPI
 
 from cpython.version cimport PY_MAJOR_VERSION  # important for determining python version in order to properly normalize string input. See http://docs.cython.org/en/latest/src/tutorial/strings.html#general-notes-about-c-strings and https://github.com/precice/precice/issues/68 .
 

--- a/cyprecice/cyprecice.pyx
+++ b/cyprecice/cyprecice.pyx
@@ -7,6 +7,7 @@ The python module precice offers python language bindings to the C++ coupling li
 
 cimport cyprecice
 import numpy as np
+from mpi4py import MPI
 
 from cpython.version cimport PY_MAJOR_VERSION  # important for determining python version in order to properly normalize string input. See http://docs.cython.org/en/latest/src/tutorial/strings.html#general-notes-about-c-strings and https://github.com/precice/precice/issues/68 .
 


### PR DESCRIPTION
Closes #72.

`from mpi4py import MPI` has to be imported in the `pyx`, not in the `pxd` file.