### PR TITLE
v2.1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## latest
+
+* Bugfix: Bindings also support empty read/write data for block read/write operations (like C++ preCICE API). https://github.com/precice/python-bindings/pull/69
+
 ## 2.1.1.1
 
 * Bindings can now handle mesh initialization with no vertices. This behavior is consistent with the C++ preCICE API.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## latest
+## 2.1.1.2
 
 * Bugfix: Bindings also support empty read/write data for block read/write operations (like C++ preCICE API). https://github.com/precice/python-bindings/pull/69
 

--- a/precice.pyx
+++ b/precice.pyx
@@ -868,8 +868,12 @@ cdef class Interface:
         """
         if not isinstance(values, np.ndarray):
             values = np.asarray(values)
-        size, dimensions = values.shape
-        assert(dimensions == self.get_dimensions())
+        if len(values) > 0:
+            size, dimensions = values.shape
+            assert(dimensions == self.get_dimensions())
+        if len(values) == 0:
+            size = 0
+
         cdef np.ndarray[int, ndim=1] _vertex_ids = np.ascontiguousarray(vertex_ids, dtype=np.int32)
         cdef np.ndarray[double, ndim=1] _values = np.ascontiguousarray(values.flatten(), dtype=np.double)
         assert(size == _vertex_ids.size)
@@ -913,6 +917,7 @@ cdef class Interface:
         """
         if not isinstance(value, np.ndarray):
             value = np.asarray(value)
+        assert(len(value) > 0)
         dimensions = value.size
         assert(dimensions == self.get_dimensions())
         cdef np.ndarray[np.double_t, ndim=1] _value = np.ascontiguousarray(value, dtype=np.double)
@@ -948,8 +953,13 @@ cdef class Interface:
         """
         cdef np.ndarray[int, ndim=1] _vertex_ids = np.ascontiguousarray(vertex_ids, dtype=np.int32)
         cdef np.ndarray[double, ndim=1] _values = np.ascontiguousarray(values, dtype=np.double)
-        assert(_values.size == _vertex_ids.size)
-        size = vertex_ids.size
+
+        if len(values) > 0:
+            assert(_values.size == _vertex_ids.size)
+            size = vertex_ids.size
+        if len(values) == 0:
+            size = 0
+
         self.thisptr.writeBlockScalarData (data_id, size, <const int*>_vertex_ids.data, <const double*>_values.data)
 
     def write_scalar_data (self, data_id, vertex_id, double value):

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ APPNAME = "pyprecice"
 # this version should be in sync with the latest supported preCICE version
 precice_version = version.Version("2.1.1")  # todo: should be replaced with precice.get_version(), if possible or we should add an assertion that makes sure that the version of preCICE is actually supported
 # this version number may be increased, if changes for the bindings are required
-bindings_version = version.Version("1")
+bindings_version = version.Version("2")
 APPVERSION = version.Version(str(precice_version) + "." + str(bindings_version))
 
 PYTHON_BINDINGS_PATH = os.path.dirname(os.path.abspath(__file__))

--- a/test/test_bindings_module.pyx
+++ b/test/test_bindings_module.pyx
@@ -195,6 +195,13 @@ class TestBindings(TestCase):
         read_data = solver_interface.read_block_scalar_data(1, np.array([1, 2, 3]))
         self.assertTrue(np.array_equal(write_data, read_data))
 
+    def test_read_write_block_scalar_data_empty(self):
+        solver_interface = precice.Interface("test", "dummy.xml", 0, 1)
+        write_data = np.array([])
+        solver_interface.write_block_scalar_data(1, [], write_data)
+        read_data = solver_interface.read_block_scalar_data(1, [])
+        self.assertTrue(len(read_data) == 0)
+
     def test_read_write_block_scalar_data_non_contiguous(self):
         """
         Tests behaviour of solver interface, if a non contiguous array is passed to the interface.
@@ -223,6 +230,13 @@ class TestBindings(TestCase):
         solver_interface.write_block_vector_data(1, np.array([1, 2]), write_data)
         read_data = solver_interface.read_block_vector_data(1, np.array([1, 2]))
         self.assertTrue(np.array_equal(write_data, read_data))
+
+    def test_read_write_block_vector_data_empty(self):
+        solver_interface = precice.Interface("test", "dummy.xml", 0, 1)
+        write_data = np.array([])
+        solver_interface.write_block_vector_data(1, [], write_data)
+        read_data = solver_interface.read_block_vector_data(1, [])
+        self.assertTrue(len(read_data) == 0)
 
     def test_read_write_block_vector_data_list(self):
         solver_interface = precice.Interface("test", "dummy.xml", 0, 1)


### PR DESCRIPTION
* Bugfix release
* Fixes bug for parallel runs via #69 
* contains `cherry-pick` of 04a663964b2a2da36d68657086af2e6d3a82fa6f