### PR TITLE
Update requirements.txt

### DIFF
--- a/solverdummy/requirements.txt
+++ b/solverdummy/requirements.txt
@@ -1,3 +1,3 @@
-pyprecice==2.0
+pyprecice>=2.0
 argparse>=1.4
 numpy>=1.16


### PR DESCRIPTION
Allow for `pyprecice` versions that are newer than 2.0. A quick check on my local machine worked out. 

That is related to https://github.com/precice/python-bindings/issues/90

Closes https://github.com/precice/python-bindings/issues/90