### PR TITLE
Remove mpi4py as dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,6 @@ Please refer to [precice.org](https://www.precice.org/installation-bindings-pyth
 
 **preCICE**: Refer to [the preCICE wiki](https://github.com/precice/precice/wiki#1-get-precice) for information on building and installation.
 
-**MPI**: `mpi4py` requires MPI to be installed on your system.
-
 # Installing the package
 
 We recommend using pip3 (version 19.0.0 or newer required) for the sake of simplicity. You can check your pip3 version via `pip3 --version`. To update pip3, use the following line:

--- a/cyprecice/cyprecice.pyx
+++ b/cyprecice/cyprecice.pyx
@@ -7,7 +7,6 @@ The python module precice offers python language bindings to the C++ coupling li
 
 cimport cyprecice
 import numpy as np
-from mpi4py import MPI
 
 from cpython.version cimport PY_MAJOR_VERSION  # important for determining python version in order to properly normalize string input. See http://docs.cython.org/en/latest/src/tutorial/strings.html#general-notes-about-c-strings and https://github.com/precice/precice/issues/68 .
 

--- a/setup.py
+++ b/setup.py
@@ -145,9 +145,7 @@ setup(
     author_email='info@precice.org',
     license='LGPL-3.0',
     python_requires='>=3',
-    install_requires=['numpy', 'mpi4py'],
-    # mpi4py is only needed, if preCICE was compiled with MPI
-    # see https://github.com/precice/python-bindings/issues/8
+    install_requires=['numpy'],
     packages=['precice'],
     zip_safe=False  # needed because setuptools are used
 )


### PR DESCRIPTION
This PR removes mpi4py (again) as a dependency.

There is some history and some other issues involved. I just added a test in #100 to be able to reproduce possible failures. Before merging this PR I would like to investigate the setup described in https://github.com/precice/python-bindings/issues/8#issuecomment-575329609 again and make sure that the error is really gone (ideally also find out why it is now gone).