### PR TITLE
Adding GitHub Actions to run partitioned-heat-conduction tutorial cases

### DIFF
--- a/.github/workflows/run-tutorials.yml
+++ b/.github/workflows/run-tutorials.yml
@@ -80,5 +80,5 @@ jobs:
         run: git clone -b develop https://github.com/precice/tutorials.git
       - name: Run tutorial
         run: | 
-          cd tutorials/partitioned-heat-conduction/fenics
+          cd tutorials/partitioned-heat-conduction-complex/fenics
           python3 heat.py -d -i complex & python3 heat.py -n -i complex

--- a/.github/workflows/run-tutorials.yml
+++ b/.github/workflows/run-tutorials.yml
@@ -1,0 +1,84 @@
+name: Run preCICE Tutorials
+on:
+  push:
+    branches:
+      - master
+      - develop
+  pull_request:
+    paths:
+      - '**'
+      
+jobs:  
+  run_ht_simple:
+    name: Run partitioned-heat-conduction-simple
+    runs-on: ubuntu-latest
+    container: precice/precice
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+      - name: Install & upgrade pip3
+        run: |
+          apt-get -yy update
+          apt-get install -y python3-pip
+          rm -rf /var/lib/apt/lists/*
+          pip3 install --upgrade --user pip
+      - name: Install dependencies
+        run: |
+          pip3 install --user toml
+          python3 -c 'import toml; c = toml.load("pyproject.toml"); print("\n".join(c["build-system"]["requires"]))' | pip3 install -r /dev/stdin
+      - name: Run setup install
+        run:  python3 setup.py install --user
+      - name: Install Dependencies & FEniCS
+        run: |
+          apt-get -qq update
+          apt-get -qq install software-properties-common python3-dev python3-pip git apt-utils
+          add-apt-repository -y ppa:fenics-packages/fenics
+          apt-get -qq install --no-install-recommends fenics
+          rm -rf /var/lib/apt/lists/*
+      - name: Install fenics-adapter
+        run:  pip3 install --user fenicsprecice
+      - name: Fix broken FEniCS installation (see https://fenicsproject.discourse.group/t/installing-python-package-with-fenics-dependency-breaks-fenics-installation/4476)
+        run: pip3 uninstall -y fenics-ufl
+      - name: Get tutorials
+        run: git clone -b develop https://github.com/precice/tutorials.git
+      - name: Run tutorial
+        run: | 
+          cd tutorials/partitioned-heat-conduction/fenics
+          python3 heat.py -d & python3 heat.py -n
+        
+  run_ht_complex:
+    name: Run partitioned-heat-conduction-complex
+    runs-on: ubuntu-latest
+    container: precice/precice
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+      - name: Install & upgrade pip3
+        run: |
+          apt-get -yy update
+          apt-get install -y python3-pip
+          rm -rf /var/lib/apt/lists/*
+          pip3 install --upgrade --user pip
+      - name: Install dependencies
+        run: |
+          pip3 install --user toml
+          python3 -c 'import toml; c = toml.load("pyproject.toml"); print("\n".join(c["build-system"]["requires"]))' | pip3 install -r /dev/stdin
+      - name: Run setup install
+        run:  python3 setup.py install --user
+      - name: Install Dependencies & FEniCS
+        run: |
+          apt-get -qq update
+          apt-get -qq install software-properties-common python3-dev python3-pip git apt-utils
+          add-apt-repository -y ppa:fenics-packages/fenics
+          apt-get -qq install --no-install-recommends fenics
+          rm -rf /var/lib/apt/lists/*
+      - name: Install fenics-adapter
+        run:  pip3 install --user fenicsprecice
+      - name: Fix broken FEniCS installation (see https://fenicsproject.discourse.group/t/installing-python-package-with-fenics-dependency-breaks-fenics-installation/4476)
+        run: pip3 uninstall -y fenics-ufl
+      - name: Get tutorials
+        run: git clone -b develop https://github.com/precice/tutorials.git
+      - name: Run tutorial
+        run: | 
+          cd tutorials/partitioned-heat-conduction/fenics
+          python3 heat.py -d -i complex & python3 heat.py -n -i complex


### PR DESCRIPTION
This PR adds GitHub Actions scripts to run the tutorial cases `partitioned-heat-conduction` and `partitioned-heat-conduction-complex`. No verification is done, just successful running of the tutorials is tested.