### PR TITLE
Remove documentation for parallel version

### DIFF
--- a/solverdummy/README.md
+++ b/solverdummy/README.md
@@ -10,10 +10,6 @@ You can test the dummy solver by coupling two instances with each other. Open tw
  * `python3 solverdummy.py precice-config.xml SolverOne MeshOne`
  * `python3 solverdummy.py precice-config.xml SolverTwo MeshTwo`
 
-## parallel version
-
-For the parallel version of the solverdummy, you have to add the command `mpirun -n <N>` to the commands from above.
-
 # Next Steps
 
 If you want to couple any other solver against this dummy solver be sure to adjust the preCICE configuration (participant names, mesh names, data names etc.) to the needs of your solver, compare our [step-by-step guide for new adapters](https://github.com/precice/precice/wiki/Adapter-Example).


### PR DESCRIPTION
Closes #110

Removes the documentation for the parallel version of the solver dummy. This is consistent with other solverdummies (https://github.com/precice/precice/blob/develop/examples/solverdummies/README.md and https://github.com/precice/fortran-module/blob/develop/examples/solverdummy/README.md). The solverdummies should be as simple as possible and therefore supporting parallel runs is out-of-scope.