### PR TITLE
Update cmdclass in setup.py to allow standard installation routine (clean fork)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -127,7 +127,7 @@ this_directory = os.path.abspath(os.path.dirname(__file__))
 with open(os.path.join(this_directory, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
-
+# Update versioneer's cmdclass to respect such that it builds the bindings
 cmdclass = versioneer.get_cmdclass()
 cmdclass.update(build_ext=my_build_ext)
 cmdclass.update(install=my_install)

--- a/setup.py
+++ b/setup.py
@@ -127,16 +127,17 @@ this_directory = os.path.abspath(os.path.dirname(__file__))
 with open(os.path.join(this_directory, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
-my_cmdclass = {
-    'test': my_test,
-    'build_ext': my_build_ext,
-    'install': my_install}
+
+cmdclass = versioneer.get_cmdclass()
+cmdclass.update(build_ext=my_build_ext)
+cmdclass.update(install=my_install)
+cmdclass.update(test=my_test)
 
 # build precice.so python extension to be added to "PYTHONPATH" later
 setup(
     name=APPNAME,
     version=versioneer.get_version(),
-    cmdclass=versioneer.get_cmdclass(my_cmdclass),
+    cmdclass=cmdclass,
     description='Python language bindings for the preCICE coupling library',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
This is almost the same as https://github.com/precice/python-bindings/pull/112, but from a clean fork. I also added a comment to the `setup.py` about updating the `cmdclass` object of Versioneer.

**Below follows the message in the original PR:**
I am currently trying to fix https://github.com/precice/python-bindings/issues/86 and https://github.com/precice/python-bindings/issues/87. Instead of trying to use another build phase I tried to go back to the initial setup of a `build_ext` phase and an `install` phase when installing the bindings via Spack. 

I could actually achieve this by restructuring the `setup.py` and the defintiion of the `cmdclass`. I update the internal command classes and this works for me. Together with my Spack package it

- Creates a `_version.py`
- Installs the bindings in the directory specified by Spack

A Spack fork using my fork of the Python bindings can be found [here](https://github.com/ajaust/spack/tree/fix-installation-routine-py-pyprecice). It contains a new package `py-pyprecice-fork` for installing that fork.

I am not completely sure of the implications of my changes. Thus, I would need some feedback whether this change of `setup.py` is legal and whether it breaks any of our tests or use cases.