### PR TITLE
Run CI also on PRs

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,5 +1,11 @@
 name: Build and Test
-on: push
+on: 
+  push:
+    branches:
+      - "*"
+  pull_request:
+    branches:
+      - "*"
       
 jobs:  
   setup_for_spack:

--- a/.github/workflows/build-spack.yml
+++ b/.github/workflows/build-spack.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - "*"
+  pull_request:
+    branches:
+      - "*"
   schedule:
     - cron: '0 4 * * 1'   # Schedule it every Sunday
       

--- a/.github/workflows/check-pep8.yml
+++ b/.github/workflows/check-pep8.yml
@@ -1,5 +1,11 @@
 name: autopep8
-on: push
+on:
+  push:
+    branches:
+      - "*"
+  pull_request:
+    branches:
+      - "*"
 jobs:
   autopep8:
     runs-on: ubuntu-latest

--- a/.github/workflows/run-solverdummy.yml
+++ b/.github/workflows/run-solverdummy.yml
@@ -1,7 +1,11 @@
 name: Run preCICE Solverdummies
 on:
   push:
-      
+    branches:
+      - "*"
+  pull_request:
+    branches:
+      - "*"
 jobs:  
   run_solverdummies:
     name: Run solverdummies


### PR DESCRIPTION
Resulting from https://github.com/precice/python-bindings/pull/117, since tests are currently not triggered by PRs from forks.