### PR TITLE
Revert #116 and fix #117

### DIFF
--- a/.github/workflows/build-spack.yml
+++ b/.github/workflows/build-spack.yml
@@ -24,6 +24,7 @@ jobs:
       - name: Move Package Script
         run: |
           cp spack/repo/packages/py-pyprecice/package.py /py-pyprecice-repo/packages/py-pyprecice/
+          cp spack/repo/packages/py-pyprecice/*.patch /py-pyprecice-repo/packages/py-pyprecice/
       - name: Try to build py-pyprecice with spack and test it
         run: |
           . /opt/spack/share/spack/setup-env.sh && spack env activate ci && spack arch && spack find && spack dev-build py-pyprecice@develop target=x86_64 && spack load precice py-numpy py-mpi4py py-cython openssh openmpi && mkdir runner && cd runner && python3 -c "import precice; print(precice.__version__)"

--- a/.github/workflows/build-spack.yml
+++ b/.github/workflows/build-spack.yml
@@ -24,7 +24,6 @@ jobs:
       - name: Move Package Script
         run: |
           cp spack/repo/packages/py-pyprecice/package.py /py-pyprecice-repo/packages/py-pyprecice/
-          cp spack/repo/packages/py-pyprecice/*.patch /py-pyprecice-repo/packages/py-pyprecice/
       - name: Try to build py-pyprecice with spack and test it
         run: |
           . /opt/spack/share/spack/setup-env.sh && spack env activate ci && spack arch && spack find && spack dev-build py-pyprecice@develop target=x86_64 && spack load precice py-numpy py-mpi4py py-cython openssh openmpi && mkdir runner && cd runner && python3 -c "import precice; print(precice.__version__)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 All notable changes to this project will be documented in this file.
 
-## latest
-
-* Synchronize spack package with https://github.com/spack/spack/pull/25077 via https://github.com/precice/python-bindings/pull/116.
-
 ## 2.2.1.1
 
 * Remove Travis CI https://github.com/precice/python-bindings/pull/103

--- a/spack/repo/packages/py-pyprecice/deactivate-version-check-via-pip.patch
+++ b/spack/repo/packages/py-pyprecice/deactivate-version-check-via-pip.patch
@@ -1,0 +1,32 @@
+diff --git a/setup.py b/setup.py
+index 9282639..d69c285 100644
+--- a/setup.py
++++ b/setup.py
+@@ -1,15 +1,20 @@
+ import os
+ import subprocess
+ import warnings
+-from packaging import version
+-import pip
++from setuptools._vendor.packaging import version
++   
++# If installed with pip we need to check its version
++try:
++    import pip
++    if version.parse(pip.__version__) < version.parse("19.0"):
++        # version 19.0 is required, since we are using pyproject.toml for definition of build-time depdendencies. See https://pip.pypa.io/en/stable/news/#id209
++        warnings.warn("You are using pip version {}. However, pip version > 19.0 is recommended. You can continue with the installation, but installation problems can occour. Please refer to https://github.com/precice/python-bindings#build-time-dependencies-cython-numpy-defined-in-pyprojecttoml-are-not-installed-automatically for help.".format(pip.__version__))
+ 
+-if version.parse(pip.__version__) < version.parse("19.0"):
+-    # version 19.0 is required, since we are using pyproject.toml for definition of build-time depdendencies. See https://pip.pypa.io/en/stable/news/#id209
+-    warnings.warn("You are using pip version {}. However, pip version > 19.0 is recommended. You can continue with the installation, but installation problems can occour. Please refer to https://github.com/precice/python-bindings#build-time-dependencies-cython-numpy-defined-in-pyprojecttoml-are-not-installed-automatically for help.".format(pip.__version__))
++    if version.parse(pip.__version__) < version.parse("10.0.1"):        
++        warnings.warn("You are using pip version {}. However, pip version > 10.0.1 is required. If you continue with installation it is likely that you will face an error. See https://github.com/precice/python-bindings#version-of-pip3-is-too-old".format(pip.__version__))
++except:
++    warnings.warn("Assuming that you are not using pip!")
+ 
+-if version.parse(pip.__version__) < version.parse("10.0.1"):        
+-    warnings.warn("You are using pip version {}. However, pip version > 10.0.1 is required. If you continue with installation it is likely that you will face an error. See https://github.com/precice/python-bindings#version-of-pip3-is-too-old".format(pip.__version__))
+ 
+ from enum import Enum
+ from setuptools import setup

--- a/spack/repo/packages/py-pyprecice/package.py
+++ b/spack/repo/packages/py-pyprecice/package.py
@@ -15,13 +15,11 @@ class PyPyprecice(PythonPackage):
     homepage = "https://www.precice.org"
     git = "https://github.com/precice/python-bindings.git"
     url = "https://github.com/precice/python-bindings/archive/v2.0.0.1.tar.gz"
-    maintainers = ["ajaust", "BenjaminRodenberg", "IshaanDesai"]
+    maintainers = ["ajaust", "BenjaminRodenberg"]
 
     # Always prefer final version of release candidate
     version("develop", branch="develop")
-    version('2.2.1.1', sha256='d96674f1ff91761c29efce34f8e09e2ec29a4862227b7204439e865dbe755a86')
-    version('2.2.0.2', sha256='2287185f9ad7500dced53459543d27bb66bd2438c2e4bf81ee3317e6a00513d5')
-    version('2.2.0.1', sha256='229625e2e6df03987ababce5abe2021b0974cbe5a588b936a9cba653f4908d4b')
+    version('2.2.0.1', sha256='032fa58193cfa69e3be37557977056e8f507d89b40c490a351d17271269b25ad')
     version('2.1.1.2', sha256='363eb3eeccf964fd5ee87012c1032353dd1518662868f2b51f04a6d8a7154045')
     version("2.1.1.1", sha256="972f574549344b6155a8dd415b6d82512e00fa154ca25ae7e36b68d4d2ed2cf4")
     version("2.1.0.1", sha256="ac5cb7412c6b96b08a04fa86ea38e52d91ea739a3bd1c209baa93a8275e4e01a")
@@ -30,8 +28,12 @@ class PyPyprecice(PythonPackage):
     version("2.0.0.2", sha256="5f055d809d65ec2e81f4d001812a250f50418de59990b47d6bcb12b88da5f5d7")
     version("2.0.0.1", sha256="96eafdf421ec61ad6fcf0ab1d3cf210831a815272984c470b2aea57d4d0c9e0e")
 
+    # Older versions of the bindings checked versions via pip. This patch
+    # removes the pip dependency.
+    # See also https://github.com/spack/spack/pull/19558
+    patch("deactivate-version-check-via-pip.patch", when="@:2.1.1.1")
+
     depends_on("precice@develop", when="@develop")
-    depends_on("precice@2.2.1", when="@2.2.1.1:2.2.1.99")
     depends_on("precice@2.2.0", when="@2.2.0.1:2.2.0.99")
     depends_on("precice@2.1.1", when="@2.1.1.1:2.1.1.99")
     depends_on("precice@2.1.0", when="@2.1.0.1:2.1.0.99")
@@ -39,16 +41,22 @@ class PyPyprecice(PythonPackage):
     depends_on("precice@2.0.1", when="@2.0.1.1:2.0.1.99")
     depends_on("precice@2.0.0", when="@2.0.0.1:2.0.0.99")
 
-    depends_on("python@3:", type=("build", "link", "run"))
+    depends_on("python@3:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
-    depends_on("py-numpy", type=("build", "link", "run"))
+    depends_on("py-numpy", type=("build", "run"))
     depends_on("py-mpi4py", type=("build", "run"))
-    depends_on("py-cython@0.29:", type="build")
-    depends_on("py-packaging", when="@:2.1", type="build")
-    depends_on("py-pip", when="@:2.1", type="build")
+    depends_on("py-cython@0.29:", type=("build"))
 
-    @when("@:2.1")
-    def patch(self):
-        filter_file(
-            "distutils.command.install", "setuptools.command.install", "setup.py"
-        )
+    phases = ['install_lib', 'build_ext', 'install']
+
+    def build_ext_args(self, spec, prefix):
+        return [
+            "--include-dirs=" + spec["precice"].headers.directories[0],
+            "--library-dirs=" + spec["precice"].libs.directories[0]
+        ]
+
+    def install(self, spec, prefix):
+        # Older versions of the bindings had a non-standard installation routine
+        # See also https://github.com/spack/spack/pull/19558#discussion_r513123239
+        if self.version <= Version("2.1.1.1"):
+            self.setup_py("install", "--prefix={0}".format(prefix))


### PR DESCRIPTION
The failure of the test in https://github.com/precice/python-bindings/commit/36e4782b8460ba93ec6bfc307bef7bf281c540fa seems to be caused by the additions from #116. Actually https://github.com/precice/python-bindings/commit/c5b19c786ad2b527dea08efe0e895c68df3ed3e9 was already failing. The missing `patch` was hiding another bug. Therefore I'm reverting #116 while keeping #117 in this PR.