### PR TITLE
Add API function to access mesh connectivity requirement

### DIFF
--- a/cyprecice/SolverInterface.pxd
+++ b/cyprecice/SolverInterface.pxd
@@ -77,6 +77,8 @@ cdef extern from "precice/SolverInterface.hpp" namespace "precice":
 
         # data access
 
+        bool isMeshConnectivityRequired (int meshID)
+
         bool hasData (const string& dataName, int meshID) const
 
         int getDataID (const string& dataName, int meshID)

--- a/cyprecice/cyprecice.pyx
+++ b/cyprecice/cyprecice.pyx
@@ -779,6 +779,23 @@ cdef class Interface:
         self.thisptr.setMeshQuadWithEdges (mesh_id, first_vertex_id, second_vertex_id, third_vertex_id, fourth_vertex_id)
 
     # data access
+
+    def is_mesh_connectivity_required (self, mesh_id):
+        """
+        Checks if the given mesh requires connectivity.
+
+        Parameters
+        ----------
+        mesh_id : int
+            ID of the associated mesh.
+
+        Returns
+        -------
+        tag : bool
+            True if mesh connectivity is required.
+        """
+        return self.thisptr.isMeshConnectivityRequired(mesh_id)
+
     def has_data (self, str data_name, mesh_id):
         """
         Checks if the data with given name is used by a solver and mesh.


### PR DESCRIPTION
Adding API function `is_mesh_connectivity_required()` based on changes to original API here: https://github.com/precice/precice/pull/1080