### PR TITLE
Add C++ compiler as dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Please refer to [the preCICE documentation](https://www.precice.org/installation
 
 **preCICE**: Refer to [the preCICE documentation](https://precice.org/installation-overview.html) for information on building and installation.
 
+**C++**: A working C++ compilers, e.g., `g++`.
+
 **MPI**: `mpi4py` requires MPI to be installed on your system.
 
 # Installing the package


### PR DESCRIPTION
This mention a C++ compiler as dependency for building the bindings in the README. It was pointed out that installation of the bindings fails, if there is no C++ compiler installed.

Do we actually need MPI as a dependency as well?