### PR TITLE
Remove mesh_name from solverdummy input arguments

### DIFF
--- a/examples/solverdummy/README.md
+++ b/examples/solverdummy/README.md
@@ -7,8 +7,8 @@
 # Run
 
 You can test the dummy solver by coupling two instances with each other. Open two terminals and run
- * `python3 solverdummy.py precice-config.xml SolverOne MeshOne`
- * `python3 solverdummy.py precice-config.xml SolverTwo MeshTwo`
+ * `python3 solverdummy.py precice-config.xml SolverOne`
+ * `python3 solverdummy.py precice-config.xml SolverTwo`
 
 # Next Steps
 

--- a/examples/solverdummy/solverdummy.py
+++ b/examples/solverdummy/solverdummy.py
@@ -8,26 +8,26 @@ parser = argparse.ArgumentParser()
 parser.add_argument("configurationFileName",
                     help="Name of the xml config file.", type=str)
 parser.add_argument("participantName", help="Name of the solver.", type=str)
-parser.add_argument("meshName", help="Name of the mesh.", type=str)
 
 try:
     args = parser.parse_args()
 except SystemExit:
     print("")
-    print("Usage: python ./solverdummy precice-config participant-name mesh-name")
+    print("Usage: python ./solverdummy precice-config participant-name")
     quit()
 
 configuration_file_name = args.configurationFileName
 participant_name = args.participantName
-mesh_name = args.meshName
 
 if participant_name == 'SolverOne':
     write_data_name = 'dataOne'
     read_data_name = 'dataTwo'
+    mesh_name = 'MeshOne'
 
 if participant_name == 'SolverTwo':
     read_data_name = 'dataOne'
     write_data_name = 'dataTwo'
+    mesh_name = 'MeshTwo'
 
 num_vertices = 3  # Number of vertices
 


### PR DESCRIPTION
The mesh name was removed from the input arguments to the other solverdummies in https://github.com/precice/precice/pull/1256. The change is now incorporated in the solverdummy in this repository for consistency.