### PR TITLE
Repairing warnings and error regarding Version.h by using pkgconfig to link to preCICE

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -45,7 +45,7 @@ jobs:
           rm -rf /var/lib/apt/lists/*
           pip3 install --upgrade --user pip
       - name: Check preCICE linkage via pkg-config
-        run: pkg-config --modversion precice
+        run: pkg-config --modversion libprecice
       - name: Install dependencies
         run: |
           pip3 install --user toml

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -97,7 +97,7 @@ jobs:
           cd precice-core
           mkdir build && cd build
           cmake .. -DPRECICE_MPICommunication=OFF -DPRECICE_PETScMapping=OFF -DPRECICE_PythonActions=OFF -DBUILD_TESTING=OFF
-          cp src/precice/Version.h ~/precice/
+          cp src/precice/Version.h ../../precice/
       - name: Install dependencies
         run: |
           python3 -c 'import toml; c = toml.load("pyproject.toml"); print("\n".join(c["build-system"]["requires"]))' | pip3 install -r /dev/stdin

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -34,7 +34,7 @@ jobs:
   setup_install:
     name: Run setup install
     runs-on: ubuntu-latest
-    container: precice/precice:2.4.0
+    container: precice/precice
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Install OpenMPI
         run: |
           sudo apt-get -yy update
-          sudo apt-get install -y libopenmpi-dev cmake
+          sudo apt-get install -y libopenmpi-dev cmake libboost-all-dev
           sudo rm -rf /var/lib/apt/lists/*
       - uses: BSFishy/pip-action@v1
         with:
@@ -96,7 +96,7 @@ jobs:
           cp precice-core/src/precice/SolverInterface.hpp precice/SolverInterface.hpp
           cd precice-core
           mkdir build && cd build
-          cmake ..
+          cmake .. -DPRECICE_MPICommunication=OFF -DPRECICE_PETScMapping=OFF -DPRECICE_PythonActions=OFF -DBUILD_TESTING=OFF
           cp src/precice/Version.h ~/precice/
       - name: Install dependencies
         run: |

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -101,6 +101,7 @@ jobs:
           PKG_CONFIG_PATH: "precice-core/build"
       - name: Install dependencies
         run: |
+          echo "$PKG_CONFIG_PATH"
           python3 -c 'import toml; c = toml.load("pyproject.toml"); print("\n".join(c["build-system"]["requires"]))' | pip3 install -r /dev/stdin
       - name: Check preCICE linkage via pkg-config
         run: pkg-config --modversion libprecice

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,7 +12,7 @@ jobs:
     name: Run setup.py phases needed by spack
     needs: [setup_test]
     runs-on: ubuntu-latest
-    container: precice/precice
+    container: precice/precice:2.4.0
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
@@ -34,7 +34,7 @@ jobs:
   setup_install:
     name: Run setup install
     runs-on: ubuntu-latest
-    container: precice/precice
+    container: precice/precice:2.4.0
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
@@ -59,7 +59,7 @@ jobs:
     name: Run setup install --single-version-externally-managed (for spack)
     needs: [setup_install]
     runs-on: ubuntu-latest
-    container: precice/precice
+    container: precice/precice:2.4.0
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
@@ -113,7 +113,7 @@ jobs:
     name: Run pip install
     needs: [setup_test]
     runs-on: ubuntu-latest
-    container: precice/precice
+    container: precice/precice:2.4.0
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
@@ -132,7 +132,7 @@ jobs:
     name: Run solverdummy
     needs: [setup_install, setup_test]
     runs-on: ubuntu-latest
-    container: precice/precice
+    container: precice/precice:2.4.0
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Install & upgrade pip3
         run: |
           apt-get -yy update
-          apt-get install -y python3-pip
+          apt-get install -y python3-pip pkg-config
           rm -rf /var/lib/apt/lists/*
           pip3 install --upgrade --user pip
       - name: Install dependencies
@@ -119,7 +119,7 @@ jobs:
       - name: Install & upgrade pip3
         run: |
           apt-get -yy update
-          apt-get install -y python3-pip
+          apt-get install -y python3-pip pkg-config
           rm -rf /var/lib/apt/lists/*
           pip3 install --upgrade --user pip
       - name: Run pip install
@@ -138,7 +138,7 @@ jobs:
       - name: Install & upgrade pip3
         run: |
           apt-get -yy update
-          apt-get install -y python3-pip
+          apt-get install -y python3-pip pkg-config
           rm -rf /var/lib/apt/lists/*
           pip3 install --upgrade --user pip
       - name: Run pip install

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install & upgrade pip3
         run: |
           apt-get -yy update
-          apt-get install -y python3-pip
+          apt-get install -y python3-pip pkg-config
           rm -rf /var/lib/apt/lists/*
           pip3 install --upgrade --user pip
       - name: Install dependencies
@@ -41,7 +41,7 @@ jobs:
       - name: Install & upgrade pip3
         run: |
           apt-get -yy update
-          apt-get install -y python3-pip
+          apt-get install -y python3-pip pkg-config
           rm -rf /var/lib/apt/lists/*
           pip3 install --upgrade --user pip
       - name: Install dependencies

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -97,15 +97,13 @@ jobs:
           cd precice-core
           mkdir build && cd build
           cmake .. -DPRECICE_MPICommunication=OFF -DPRECICE_PETScMapping=OFF -DPRECICE_PythonActions=OFF -DBUILD_TESTING=OFF
-        env:
-          PKG_CONFIG_PATH: "precice-core/build"
       - name: Install dependencies
         run: |
           echo "$PKG_CONFIG_PATH"
           python3 -c 'import toml; c = toml.load("pyproject.toml"); print("\n".join(c["build-system"]["requires"]))' | pip3 install -r /dev/stdin
-      - name: Check preCICE linkage via pkg-config
-        run: pkg-config --modversion libprecice
       - name: Run setup test
+        env:
+          PKG_CONFIG_PATH: "precice-core/build"
         run: |
           export CFLAGS=-I$GITHUB_WORKSPACE
           python3 setup.py test

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Install OpenMPI
         run: |
           sudo apt-get -yy update
-          sudo apt-get install -y libopenmpi-dev cmake libboost-all-dev
+          sudo apt-get install -y libopenmpi-dev cmake libboost-all-dev libeigen3-dev
           sudo rm -rf /var/lib/apt/lists/*
       - uses: BSFishy/pip-action@v1
         with:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Install OpenMPI
         run: |
           sudo apt-get -yy update
-          sudo apt-get install -y libopenmpi-dev cmake libboost-all-dev libeigen3-dev
+          sudo apt-get install -y libopenmpi-dev cmake libboost-all-dev libeigen3-dev pkg-config
           sudo rm -rf /var/lib/apt/lists/*
       - uses: BSFishy/pip-action@v1
         with:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -99,14 +99,12 @@ jobs:
           cmake .. -DPRECICE_MPICommunication=OFF -DPRECICE_PETScMapping=OFF -DPRECICE_PythonActions=OFF -DBUILD_TESTING=OFF
       - name: Install dependencies
         run: |
-          echo "$PKG_CONFIG_PATH"
           python3 -c 'import toml; c = toml.load("pyproject.toml"); print("\n".join(c["build-system"]["requires"]))' | pip3 install -r /dev/stdin
       - name: Run setup test
         env:
           PKG_CONFIG_PATH: "precice-core/build"
           PKG_CONFIG_SYSTEM_INCLUDE_PATH: 1
         run: |
-          pkg-config --modversion libprecice
           export CFLAGS=-I$GITHUB_WORKSPACE
           python3 setup.py test
         

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -44,6 +44,8 @@ jobs:
           apt-get install -y python3-pip pkg-config
           rm -rf /var/lib/apt/lists/*
           pip3 install --upgrade --user pip
+      - name: Check preCICE linkage via pkg-config
+        run: pkg-config --modversion precice
       - name: Install dependencies
         run: |
           pip3 install --user toml
@@ -98,7 +100,7 @@ jobs:
           mkdir build && cd build
           cmake .. -DPRECICE_MPICommunication=OFF -DPRECICE_PETScMapping=OFF -DPRECICE_PythonActions=OFF -DBUILD_TESTING=OFF
         env:
-          PKG_CONFIG_PATH: "precice-core/build/lib/pkgconfig"
+          PKG_CONFIG_PATH: "precice-core/build"
       - name: Install dependencies
         run: |
           python3 -c 'import toml; c = toml.load("pyproject.toml"); print("\n".join(c["build-system"]["requires"]))' | pip3 install -r /dev/stdin

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Install OpenMPI
         run: |
           sudo apt-get -yy update
-          sudo apt-get install -y libopenmpi-dev
+          sudo apt-get install -y libopenmpi-dev cmake
           sudo rm -rf /var/lib/apt/lists/*
       - uses: BSFishy/pip-action@v1
         with:
@@ -94,6 +94,10 @@ jobs:
           git clone https://github.com/precice/precice.git precice-core
           mkdir -p precice
           cp precice-core/src/precice/SolverInterface.hpp precice/SolverInterface.hpp
+          cd precice-core
+          mkdir build && cd build
+          cmake ..
+          cp src/precice/Version.h ~/precice/
       - name: Install dependencies
         run: |
           python3 -c 'import toml; c = toml.load("pyproject.toml"); print("\n".join(c["build-system"]["requires"]))' | pip3 install -r /dev/stdin

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -104,6 +104,7 @@ jobs:
       - name: Run setup test
         env:
           PKG_CONFIG_PATH: "precice-core/build"
+          PKG_CONFIG_SYSTEM_INCLUDE_PATH: 1
         run: |
           pkg-config --modversion libprecice
           export CFLAGS=-I$GITHUB_WORKSPACE

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -97,7 +97,8 @@ jobs:
           cd precice-core
           mkdir build && cd build
           cmake .. -DPRECICE_MPICommunication=OFF -DPRECICE_PETScMapping=OFF -DPRECICE_PythonActions=OFF -DBUILD_TESTING=OFF
-          cp src/precice/Version.h ../../precice/
+        env:
+          PKG_CONFIG_PATH: "precice-core/build/lib/pkgconfig"
       - name: Install dependencies
         run: |
           python3 -c 'import toml; c = toml.load("pyproject.toml"); print("\n".join(c["build-system"]["requires"]))' | pip3 install -r /dev/stdin

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,7 +12,7 @@ jobs:
     name: Run setup.py phases needed by spack
     needs: [setup_test]
     runs-on: ubuntu-latest
-    container: precice/precice:2.4.0
+    container: precice/precice
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
@@ -57,7 +57,7 @@ jobs:
     name: Run setup install --single-version-externally-managed (for spack)
     needs: [setup_install]
     runs-on: ubuntu-latest
-    container: precice/precice:2.4.0
+    container: precice/precice
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
@@ -112,7 +112,7 @@ jobs:
     name: Run pip install
     needs: [setup_test]
     runs-on: ubuntu-latest
-    container: precice/precice:2.4.0
+    container: precice/precice
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
@@ -131,7 +131,7 @@ jobs:
     name: Run solverdummy
     needs: [setup_install, setup_test]
     runs-on: ubuntu-latest
-    container: precice/precice:2.4.0
+    container: precice/precice
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -105,6 +105,7 @@ jobs:
         env:
           PKG_CONFIG_PATH: "precice-core/build"
         run: |
+          pkg-config --modversion libprecice
           export CFLAGS=-I$GITHUB_WORKSPACE
           python3 setup.py test
         

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -44,8 +44,6 @@ jobs:
           apt-get install -y python3-pip pkg-config
           rm -rf /var/lib/apt/lists/*
           pip3 install --upgrade --user pip
-      - name: Check preCICE linkage via pkg-config
-        run: pkg-config --modversion libprecice
       - name: Install dependencies
         run: |
           pip3 install --user toml
@@ -104,6 +102,8 @@ jobs:
       - name: Install dependencies
         run: |
           python3 -c 'import toml; c = toml.load("pyproject.toml"); print("\n".join(c["build-system"]["requires"]))' | pip3 install -r /dev/stdin
+      - name: Check preCICE linkage via pkg-config
+        run: pkg-config --modversion libprecice
       - name: Run setup test
         run: |
           export CFLAGS=-I$GITHUB_WORKSPACE

--- a/.github/workflows/run-solverdummy.yml
+++ b/.github/workflows/run-solverdummy.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install Dependencies
         run: |
           apt-get -qq update
-          apt-get -qq install software-properties-common python3-dev python3-pip git apt-utils
+          apt-get -qq install software-properties-common python3-dev python3-pip git apt-utils pkg-config
           rm -rf /var/lib/apt/lists/*
       - name: Install bindings
         run:  pip3 install --user .

--- a/cyprecice/cyprecice.pyx
+++ b/cyprecice/cyprecice.pyx
@@ -1207,7 +1207,7 @@ cdef class Interface:
         >>> vertex_id = 5
         >>> value = interface.read_scalar_data(data_id, vertex_id)
         """
-        cdef double _value
+        cdef double _value = 0
         self.thisptr.readScalarData (data_id, vertex_id, _value)
         return _value
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
 # PEP 518 - minimum build system requirements
-requires = ["setuptools", "wheel", "Cython>=0.29", "packaging", "pip>=19.0.0", "numpy", "mpi4py"]
+requires = ["setuptools", "wheel", "Cython>=0.29", "packaging", "pip>=19.0.0", "numpy", "mpi4py", "pkgconfig"]

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ def get_extensions(is_test):
     bindings_sources = [os.path.join(PYTHON_BINDINGS_PATH, "cyprecice",
                                      "cyprecice" + ".pyx")]
 
-    compile_args.append(pkgconfig.cflags('libprecice').strip('"'))
+    compile_args += pkgconfig.cflags('libprecice').split()
 
     if not is_test:
         link_args.append(pkgconfig.libs('libprecice'))

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,7 @@ def get_extensions(is_test):
     if not is_test:
         link_args.append(pkgconfig.libs('libprecice'))
     if is_test:
+        link_args.append(pkgconfig.libs('libprecice'))  # Mocked preCICE needs to find generated headers
         bindings_sources.append(os.path.join(PYTHON_BINDINGS_PATH, "test",
                                              "SolverInterface.cpp"))
 

--- a/setup.py
+++ b/setup.py
@@ -70,10 +70,11 @@ def get_extensions(is_test):
     bindings_sources = [os.path.join(PYTHON_BINDINGS_PATH, "cyprecice",
                                      "cyprecice" + ".pyx")]
 
+    compile_args.append(pkgconfig.cflags('libprecice'))
+
     if not is_test:
         link_args.append(pkgconfig.libs('libprecice'))
     if is_test:
-        link_args.append(pkgconfig.libs('libprecice'))  # Mocked preCICE needs to find generated headers
         bindings_sources.append(os.path.join(PYTHON_BINDINGS_PATH, "test",
                                              "SolverInterface.cpp"))
 

--- a/setup.py
+++ b/setup.py
@@ -147,7 +147,7 @@ setup(
     author_email='info@precice.org',
     license='LGPL-3.0',
     python_requires='>=3',
-    install_requires=['numpy', 'mpi4py', 'pkgconfig'],
+    install_requires=['numpy', 'mpi4py'],
     # mpi4py is only needed, if preCICE was compiled with MPI
     # see https://github.com/precice/python-bindings/issues/8
     packages=['precice'],

--- a/setup.py
+++ b/setup.py
@@ -70,9 +70,8 @@ def get_extensions(is_test):
     bindings_sources = [os.path.join(PYTHON_BINDINGS_PATH, "cyprecice",
                                      "cyprecice" + ".pyx")]
 
-    link_args.append(pkgconfig.libs('libprecice'))
-    compile_args.append(pkgconfig.cflags('libprecice'))
-
+    if not is_test:
+        link_args.append(pkgconfig.libs('libprecice'))
     if is_test:
         bindings_sources.append(os.path.join(PYTHON_BINDINGS_PATH, "test",
                                              "SolverInterface.cpp"))

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ def get_extensions(is_test):
                                      "cyprecice" + ".pyx")]
 
     link_args.append(pkgconfig.libs('libprecice'))
-    compile_args.append(pkconfig.cflags('libprecice'))
+    compile_args.append(pkgconfig.cflags('libprecice'))
 
     if is_test:
         bindings_sources.append(os.path.join(PYTHON_BINDINGS_PATH, "test",

--- a/setup.py
+++ b/setup.py
@@ -70,10 +70,10 @@ def get_extensions(is_test):
     bindings_sources = [os.path.join(PYTHON_BINDINGS_PATH, "cyprecice",
                                      "cyprecice" + ".pyx")]
 
-    if not is_test:
-        link_args.append(pkgconfig.libs('precice'))
+    link_args.append(pkgconfig.libs('libprecice'))
+    compile_args.append(pkconfig.cflags('libprecice'))
+
     if is_test:
-        link_args.append(pkgconfig.libs('precice'))
         bindings_sources.append(os.path.join(PYTHON_BINDINGS_PATH, "test",
                                              "SolverInterface.cpp"))
 

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ def get_extensions(is_test):
     bindings_sources = [os.path.join(PYTHON_BINDINGS_PATH, "cyprecice",
                                      "cyprecice" + ".pyx")]
 
-    compile_args.append(pkgconfig.cflags('libprecice').split())
+    compile_args.append(pkgconfig.cflags('libprecice').strip('"'))
 
     if not is_test:
         link_args.append(pkgconfig.libs('libprecice'))

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ from Cython.Distutils.extension import Extension
 from Cython.Distutils.build_ext import new_build_ext as build_ext
 from Cython.Build import cythonize
 import numpy
+import pkgconfig
 
 
 # name of Interfacing API
@@ -70,8 +71,9 @@ def get_extensions(is_test):
                                      "cyprecice" + ".pyx")]
 
     if not is_test:
-        link_args.append("-lprecice")
+        link_args.append(pkgconfig.libs('precice'))
     if is_test:
+        link_args.append(pkgconfig.libs('precice'))
         bindings_sources.append(os.path.join(PYTHON_BINDINGS_PATH, "test",
                                              "SolverInterface.cpp"))
 
@@ -145,7 +147,7 @@ setup(
     author_email='info@precice.org',
     license='LGPL-3.0',
     python_requires='>=3',
-    install_requires=['numpy', 'mpi4py'],
+    install_requires=['numpy', 'mpi4py', 'pkgconfig'],
     # mpi4py is only needed, if preCICE was compiled with MPI
     # see https://github.com/precice/python-bindings/issues/8
     packages=['precice'],

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ def get_extensions(is_test):
     bindings_sources = [os.path.join(PYTHON_BINDINGS_PATH, "cyprecice",
                                      "cyprecice" + ".pyx")]
 
-    compile_args.append(pkgconfig.cflags('libprecice'))
+    compile_args.append(pkgconfig.cflags('libprecice').split())
 
     if not is_test:
         link_args.append(pkgconfig.libs('libprecice'))


### PR DESCRIPTION
This PR resolves a warning and an error in the action set of `build-and-test`. The warning was:

```bash
warning: cyprecice/cyprecice.pyx:1211:57: local variable '_value' referenced before assignment
```
and the error was
```bash
/home/runner/work/python-bindings/python-bindings/precice/SolverInterface.hpp:7:10: fatal error: precice/Version.h: No such file or directory
    7 | #include "precice/Version.h"
      |          ^~~~~~~~~~~~~~~~~~~
```
