### PR TITLE
Release v2.5.0.0

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
-      - name: Install & upgrade pip3
+      - name: Install pip3, pkgconfig and upgrade pip3
         run: |
           apt-get -yy update
           apt-get install -y python3-pip pkg-config
@@ -61,7 +61,7 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
-      - name: Install & upgrade pip3
+      - name: Install pip3, pkgconfig and upgrade pip3
         run: |
           apt-get -yy update
           apt-get install -y python3-pip pkg-config
@@ -81,7 +81,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v2
       - uses: actions/setup-python@v1
-      - name: Install OpenMPI
+      - name: Install OpenMPI, CMake, Boost library, Eigen and pkg-config
         run: |
           sudo apt-get -yy update
           sudo apt-get install -y libopenmpi-dev cmake libboost-all-dev libeigen3-dev pkg-config
@@ -116,7 +116,7 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
-      - name: Install & upgrade pip3
+      - name: Install pip3, pkgconfig and upgrade pip3
         run: |
           apt-get -yy update
           apt-get install -y python3-pip pkg-config
@@ -135,7 +135,7 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
-      - name: Install & upgrade pip3
+      - name: Install pip3, pkgconfig and upgrade pip3
         run: |
           apt-get -yy update
           apt-get install -y python3-pip pkg-config

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -80,12 +80,15 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
-      - name: Install & upgrade pip3 and install OpenMPI
+      - uses: actions/setup-python@v1
+      - name: Install OpenMPI
         run: |
           sudo apt-get -yy update
-          sudo apt-get install -y python3-pip libopenmpi-dev
+          sudo apt-get install -y libopenmpi-dev
           sudo rm -rf /var/lib/apt/lists/*
-          pip3 install --upgrade --user pip
+      - uses: BSFishy/pip-action@v1
+        with:
+          packages: toml
       - name: Checkout precice and make required files discoverable
         run: |
           git clone https://github.com/precice/precice.git precice-core
@@ -93,7 +96,6 @@ jobs:
           cp precice-core/src/precice/SolverInterface.hpp precice/SolverInterface.hpp
       - name: Install dependencies
         run: |
-          pip3 install --user toml
           python3 -c 'import toml; c = toml.load("pyproject.toml"); print("\n".join(c["build-system"]["requires"]))' | pip3 install -r /dev/stdin
       - name: Run setup test
         run: |

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install & upgrade pip3
         run: |
           apt-get -yy update
-          apt-get install -y python3-pip
+          apt-get install -y python3-pip pkg-config
           rm -rf /var/lib/apt/lists/*
           pip3 install --upgrade --user pip
       - name: Install dependencies
@@ -41,7 +41,7 @@ jobs:
       - name: Install & upgrade pip3
         run: |
           apt-get -yy update
-          apt-get install -y python3-pip
+          apt-get install -y python3-pip pkg-config
           rm -rf /var/lib/apt/lists/*
           pip3 install --upgrade --user pip
       - name: Install dependencies
@@ -64,7 +64,7 @@ jobs:
       - name: Install & upgrade pip3
         run: |
           apt-get -yy update
-          apt-get install -y python3-pip
+          apt-get install -y python3-pip pkg-config
           rm -rf /var/lib/apt/lists/*
           pip3 install --upgrade --user pip
       - name: Install dependencies
@@ -84,7 +84,7 @@ jobs:
       - name: Install OpenMPI
         run: |
           sudo apt-get -yy update
-          sudo apt-get install -y libopenmpi-dev
+          sudo apt-get install -y libopenmpi-dev cmake libboost-all-dev libeigen3-dev pkg-config
           sudo rm -rf /var/lib/apt/lists/*
       - uses: BSFishy/pip-action@v1
         with:
@@ -94,10 +94,16 @@ jobs:
           git clone https://github.com/precice/precice.git precice-core
           mkdir -p precice
           cp precice-core/src/precice/SolverInterface.hpp precice/SolverInterface.hpp
+          cd precice-core
+          mkdir build && cd build
+          cmake .. -DPRECICE_MPICommunication=OFF -DPRECICE_PETScMapping=OFF -DPRECICE_PythonActions=OFF -DBUILD_TESTING=OFF
       - name: Install dependencies
         run: |
           python3 -c 'import toml; c = toml.load("pyproject.toml"); print("\n".join(c["build-system"]["requires"]))' | pip3 install -r /dev/stdin
       - name: Run setup test
+        env:
+          PKG_CONFIG_PATH: "precice-core/build"
+          PKG_CONFIG_SYSTEM_INCLUDE_PATH: 1
         run: |
           export CFLAGS=-I$GITHUB_WORKSPACE
           python3 setup.py test
@@ -113,7 +119,7 @@ jobs:
       - name: Install & upgrade pip3
         run: |
           apt-get -yy update
-          apt-get install -y python3-pip
+          apt-get install -y python3-pip pkg-config
           rm -rf /var/lib/apt/lists/*
           pip3 install --upgrade --user pip
       - name: Run pip install
@@ -132,7 +138,7 @@ jobs:
       - name: Install & upgrade pip3
         run: |
           apt-get -yy update
-          apt-get install -y python3-pip
+          apt-get install -y python3-pip pkg-config
           rm -rf /var/lib/apt/lists/*
           pip3 install --upgrade --user pip
       - name: Run pip install

--- a/.github/workflows/build-env.yml
+++ b/.github/workflows/build-env.yml
@@ -24,5 +24,5 @@ jobs:
         with:
           push: true
           context: .
-          file: spack/ci-spack-pyprecice-deps-1804.dockerfile
-          tags: precice/ci-spack-pyprecice-deps-1804
+          file: spack/ci-spack-pyprecice-deps-2204.dockerfile
+          tags: precice/ci-spack-pyprecice-deps-2204

--- a/.github/workflows/build-spack.yml
+++ b/.github/workflows/build-spack.yml
@@ -28,8 +28,8 @@ jobs:
         run: |
           . /opt/spack/share/spack/setup-env.sh 
           spack env activate ci && spack arch
-          spack develop pyprecice.test.py-pyprecice@develop target=x86_64
-          spack install
-          spack find
+          spack remove py-pyprecice
+          spack add pyprecice.test.py-pyprecice@develop && spack develop pyprecice.test.py-pyprecice@develop
+          spack install && spack find
           spack load py-pyprecice
           BINDINGS_VERSION=$(python3 -c "import precice; print(precice.__version__)") && echo "Installed version of bindings is ${BINDINGS_VERSION}"

--- a/.github/workflows/build-spack.yml
+++ b/.github/workflows/build-spack.yml
@@ -26,8 +26,6 @@ jobs:
           cp -r spack/repo/packages/py-pyprecice/ /py-pyprecice-repo/packages/
       - name: Try to build py-pyprecice with spack and test it
         run: |
-          apt-get -yy update
-          apt-get install -y lsb-release
           . /opt/spack/share/spack/setup-env.sh 
           spack env activate ci && spack arch
           spack develop pyprecice.test.py-pyprecice@develop target=x86_64

--- a/.github/workflows/build-spack.yml
+++ b/.github/workflows/build-spack.yml
@@ -14,7 +14,7 @@ jobs:
     name: build_spack
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    container: precice/ci-spack-pyprecice-deps-1804
+    container: precice/ci-spack-pyprecice-deps-2204
     defaults:
       run:
         shell: "bash --login -eo pipefail {0}"
@@ -26,4 +26,12 @@ jobs:
           cp -r spack/repo/packages/py-pyprecice/ /py-pyprecice-repo/packages/
       - name: Try to build py-pyprecice with spack and test it
         run: |
-          . /opt/spack/share/spack/setup-env.sh && spack env activate ci && spack arch && spack find && spack dev-build pyprecice.test.py-pyprecice@develop target=x86_64 && spack load precice py-numpy py-mpi4py py-cython openssh openmpi && export PYTHONPATH=${PWD}/build/$(ls build | grep lib.):${PYTHONPATH} && mkdir runner && cd runner && BINDINGS_VERSION=$(python3 -c "import precice; print(precice.__version__)") && echo "Installed version of bindings is ${BINDINGS_VERSION}"
+          apt-get -yy update
+          apt-get install -y lsb-release
+          . /opt/spack/share/spack/setup-env.sh 
+          spack env activate ci && spack arch
+          spack develop pyprecice.test.py-pyprecice@develop target=x86_64
+          spack install
+          spack find
+          spack load py-pyprecice
+          BINDINGS_VERSION=$(python3 -c "import precice; print(precice.__version__)") && echo "Installed version of bindings is ${BINDINGS_VERSION}"

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -15,9 +15,15 @@ jobs:
       with:
         python-version: '3.x'
     - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install setuptools wheel twine cython packaging numpy
+      uses: BSFishy/pip-action@v1
+      with:
+        packages: |
+          setuptools
+          wheel
+          twine
+          cython
+          packaging
+          numpy
     - name: Build and publish
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}

--- a/.github/workflows/run-solverdummy.yml
+++ b/.github/workflows/run-solverdummy.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install Dependencies
         run: |
           apt-get -qq update
-          apt-get -qq install software-properties-common python3-dev python3-pip git apt-utils
+          apt-get -qq install software-properties-common python3-dev python3-pip git apt-utils pkg-config
           rm -rf /var/lib/apt/lists/*
       - name: Install bindings
         run:  pip3 install --user .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## latest
 
+## 2.5.0.0
+
+* Bindings now use pkgconfig to determine flags and link to preCICE. https://github.com/precice/python-bindings/pull/149
+
 ## 2.4.0.0
 
 * Move solverdummy into examples/ folder and remove MeshName from its input arguments. https://github.com/precice/python-bindings/pull/141

--- a/cyprecice/cyprecice.pyx
+++ b/cyprecice/cyprecice.pyx
@@ -1207,7 +1207,7 @@ cdef class Interface:
         >>> vertex_id = 5
         >>> value = interface.read_scalar_data(data_id, vertex_id)
         """
-        cdef double _value
+        cdef double _value = 0
         self.thisptr.readScalarData (data_id, vertex_id, _value)
         return _value
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
 # PEP 518 - minimum build system requirements
-requires = ["setuptools", "wheel", "Cython>=0.29", "packaging", "pip>=19.0.0", "numpy", "mpi4py"]
+requires = ["setuptools", "wheel", "Cython>=0.29", "packaging", "pip>=19.0.0", "numpy", "mpi4py", "pkgconfig"]

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ from Cython.Distutils.extension import Extension
 from Cython.Distutils.build_ext import new_build_ext as build_ext
 from Cython.Build import cythonize
 import numpy
+import pkgconfig
 
 
 # name of Interfacing API
@@ -69,8 +70,10 @@ def get_extensions(is_test):
     bindings_sources = [os.path.join(PYTHON_BINDINGS_PATH, "cyprecice",
                                      "cyprecice" + ".pyx")]
 
+    compile_args += pkgconfig.cflags('libprecice').split()
+
     if not is_test:
-        link_args.append("-lprecice")
+        link_args.append(pkgconfig.libs('libprecice'))
     if is_test:
         bindings_sources.append(os.path.join(PYTHON_BINDINGS_PATH, "test",
                                              "SolverInterface.cpp"))

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ def get_extensions(is_test):
     compile_args += pkgconfig.cflags('libprecice').split()
 
     if not is_test:
-        link_args.append(pkgconfig.libs('libprecice'))
+        link_args += pkgconfig.libs('libprecice').split()
     if is_test:
         bindings_sources.append(os.path.join(PYTHON_BINDINGS_PATH, "test",
                                              "SolverInterface.cpp"))

--- a/spack/README.md
+++ b/spack/README.md
@@ -2,11 +2,11 @@
 
 The Spack package `py-pyprecice` provides the python bindings via Spack and was submitted via [pull request 19558](https://github.com/spack/spack/pull/19558) in the Spack repository. This folder contains the Spack package script that can be used for testing whether the Spack installation works.
 
-## Docker image `precice/ci-spack-pyprecice-deps-1804`
+## Docker image `precice/ci-spack-pyprecice-deps-2204`
 
-The workflow `build-spack-pyprecice-deps` in `.github/workflows/build-env.yml` creates the image `precice/ci-spack-pyprecice-deps-1804`. This image contains all dependencies of `py-pyprecice@develop`.
+The workflow `build-spack-pyprecice-deps` in `.github/workflows/build-env.yml` creates the image `precice/ci-spack-pyprecice-deps-2204`. This image contains all dependencies of `py-pyprecice@develop`.
 
-The workflow `build_spack` in `.github/workflows/build-spack.yml` uses the image `precice/ci-spack-pyprecice-deps-1804` to reduce build time. The workflow uses the `package.py` from this repository to build the latest version of the bindings and run a small test on this version.
+The workflow `build_spack` in `.github/workflows/build-spack.yml` uses the image `precice/ci-spack-pyprecice-deps-2204` to reduce build time. The workflow uses the `package.py` from this repository to build the latest version of the bindings and run a small test on this version.
 
 ## When a new Spack release is necessary
 

--- a/spack/ci-spack-pyprecice-deps-2204.dockerfile
+++ b/spack/ci-spack-pyprecice-deps-2204.dockerfile
@@ -1,5 +1,5 @@
 # Build stage with Spack pre-installed and ready to be used
-FROM spack/ubuntu-bionic:latest
+FROM spack/ubuntu-jammy:latest
 
 # Mount the current sources into the build container
 # and build the default environment

--- a/spack/repo/packages/py-pyprecice/package.py
+++ b/spack/repo/packages/py-pyprecice/package.py
@@ -1,9 +1,9 @@
-# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
+from spack.package import *
 
 
 class PyPyprecice(PythonPackage):
@@ -14,16 +14,17 @@ class PyPyprecice(PythonPackage):
 
     homepage = "https://precice.org"
     git = "https://github.com/precice/python-bindings.git"
-    url = "https://github.com/precice/python-bindings/archive/v2.0.0.1.tar.gz"
+    url = "https://github.com/precice/python-bindings/archive/v2.4.0.0.tar.gz"
     maintainers = ["ajaust", "BenjaminRodenberg", "IshaanDesai"]
 
     # Always prefer final version of release candidate
     version("develop", branch="develop")
-    version('2.3.0.1', sha256='ed4e48729b662680beaa4ee2a9aff724a79e760534c6c58181be739988da2789')
-    version('2.2.1.1', sha256='139bac5077c3807e1b7b83d8d0da5ca0fc8c17393fd0df4bc5999cd63a351b78')
-    version('2.2.0.2', sha256='2287185f9ad7500dced53459543d27bb66bd2438c2e4bf81ee3317e6a00513d5')
-    version('2.2.0.1', sha256='229625e2e6df03987ababce5abe2021b0974cbe5a588b936a9cba653f4908d4b')
-    version('2.1.1.2', sha256='363eb3eeccf964fd5ee87012c1032353dd1518662868f2b51f04a6d8a7154045')
+    version("2.4.0.0", sha256="8877da85df97d66966892440c7e777b667d8e6a33747304ed3762f4c33b729ec")
+    version("2.3.0.1", sha256="ed4e48729b662680beaa4ee2a9aff724a79e760534c6c58181be739988da2789")
+    version("2.2.1.1", sha256="139bac5077c3807e1b7b83d8d0da5ca0fc8c17393fd0df4bc5999cd63a351b78")
+    version("2.2.0.2", sha256="2287185f9ad7500dced53459543d27bb66bd2438c2e4bf81ee3317e6a00513d5")
+    version("2.2.0.1", sha256="229625e2e6df03987ababce5abe2021b0974cbe5a588b936a9cba653f4908d4b")
+    version("2.1.1.2", sha256="363eb3eeccf964fd5ee87012c1032353dd1518662868f2b51f04a6d8a7154045")
     version("2.1.1.1", sha256="972f574549344b6155a8dd415b6d82512e00fa154ca25ae7e36b68d4d2ed2cf4")
     version("2.1.0.1", sha256="ac5cb7412c6b96b08a04fa86ea38e52d91ea739a3bd1c209baa93a8275e4e01a")
     version("2.0.2.1", sha256="c6fca26332316de041f559aecbf23122a85d6348baa5d3252be4ddcd5e94c09a")
@@ -32,6 +33,7 @@ class PyPyprecice(PythonPackage):
     version("2.0.0.1", sha256="96eafdf421ec61ad6fcf0ab1d3cf210831a815272984c470b2aea57d4d0c9e0e")
 
     depends_on("precice@develop", when="@develop")
+    depends_on("precice@2.4.0", when="@2.4.0.1:2.4.0")
     depends_on("precice@2.3.0", when="@2.3.0.1:2.3.1")
     depends_on("precice@2.2.1", when="@2.2.1.1:2.2.1")
     depends_on("precice@2.2.0", when="@2.2.0.1:2.2.0")
@@ -46,11 +48,9 @@ class PyPyprecice(PythonPackage):
     depends_on("py-numpy", type=("build", "link", "run"))
     depends_on("py-mpi4py", type=("build", "run"))
     depends_on("py-cython@0.29:", type="build")
-    depends_on("py-packaging", when="@:2.1", type="build")
-    depends_on("py-pip", when="@:2.1", type="build")
+    depends_on("py-packaging", type="build")
+    depends_on("py-pip@19.0.0:", type="build")
 
     @when("@:2.1")
     def patch(self):
-        filter_file(
-            "distutils.command.install", "setuptools.command.install", "setup.py"
-        )
+        filter_file("distutils.command.install", "setuptools.command.install", "setup.py")

--- a/spack/repo/packages/py-pyprecice/package.py
+++ b/spack/repo/packages/py-pyprecice/package.py
@@ -50,6 +50,7 @@ class PyPyprecice(PythonPackage):
     depends_on("py-cython@0.29:", type="build")
     depends_on("py-packaging", type="build")
     depends_on("py-pip@19.0.0:", type="build")
+    depends_on("py-pkgconfig", type="build")
 
     @when("@:2.1")
     def patch(self):

--- a/tools/releasing/packaging/docker/Dockerfile
+++ b/tools/releasing/packaging/docker/Dockerfile
@@ -12,7 +12,8 @@ RUN apt-get -qq update && apt-get -qq install \
     git \
     sudo \
     python3-dev \
-    python3-pip && \
+    python3-pip \
+    pkg-config && \
     rm -rf /var/lib/apt/lists/*
 
 ## Needed, because precice/precice:latest does not create a user? See also https://github.com/precice/precice/pull/1090


### PR DESCRIPTION
Release for preCICE [v2.5.0](https://github.com/precice/precice/releases/tag/v2.5.0)

Main features:

* Bindings now use pkgconfig to determine flags and link to preCICE https://github.com/precice/python-bindings/pull/149