### PR TITLE
Adapted compatibility-precice-dev branch

### DIFF
--- a/cyprecice/cyprecice.pyx
+++ b/cyprecice/cyprecice.pyx
@@ -220,13 +220,38 @@ cdef class Interface:
 
     def requires_initial_data (self):
         """
-        
+        Checks if the participant is required to provide initial data.
+        If true, then the participant needs to write initial data to defined vertices
+        prior to calling initialize().
+
+        Returns
+        -------
+        tag : bool
+            Returns True if inital data is required.
+
+        Notes
+        -----
+        Previous calls:
+            initialize() has not yet been called
         """
         return self.thisptr.requiresInitialData ()
 
     def requires_reading_checkpoint (self):
         """
+        Checks if the participant is required to read an iteration checkpoint.
         
+        If true, the participant is required to read an iteration checkpoint before
+        calling advance().
+
+        preCICE refuses to proceed if reading a checkpoint is required,
+        but this method isn't called prior to advance().
+
+        Notes
+        -----
+        This function returns false before the first call to advance().
+
+        Previous calls:
+            initialize() has been called
         """
         return self.thisptr.requiresReadingCheckpoint ()
 
@@ -554,7 +579,7 @@ cdef class Interface:
         Previous calls:
             vertices with firstVertexID and secondVertexID were added to the mesh with the ID meshID
         """
-        return self.thisptr.setMeshEdge (mesh_id, first_vertex_id, second_vertex_id)
+        self.thisptr.setMeshEdge (mesh_id, first_vertex_id, second_vertex_id)
 
     def set_mesh_edges (self, mesh_id, vertices):
         """

--- a/cyprecice/cyprecice.pyx
+++ b/cyprecice/cyprecice.pyx
@@ -257,7 +257,18 @@ cdef class Interface:
 
     def requires_writing_checkpoint (self):
         """
+        Checks if the participant is required to write an iteration checkpoint.
         
+        If true, the participant is required to write an iteration checkpoint before
+        calling advance().
+        
+        preCICE refuses to proceed if writing a checkpoint is required,
+        but this method isn't called prior to advance().
+
+        Notes
+        -----
+        Previous calls:
+            initialize() has been called
         """
         return self.thisptr.requiresWritingCheckpoint ()
 

--- a/precice/__init__.py
+++ b/precice/__init__.py
@@ -1,7 +1,8 @@
+from ._version import get_versions
 __version__ = "unknown"
 
 import warnings
-from cyprecice import Interface, action_read_iteration_checkpoint, action_write_iteration_checkpoint, action_write_initial_data, get_version_information
+from cyprecice import Interface, get_version_information
 
 
 def SolverInterface(*args):
@@ -11,6 +12,5 @@ def SolverInterface(*args):
     warnings.warn("please use precice.Interface to create the interface to C++ preCICE. Note that this function (precice.SolverInterface) does not do anything but throwing this warning. See https://github.com/precice/python-bindings/issues/92 for more information.")
 
 
-from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions


### PR DESCRIPTION
- Added docstrings for some functions
- Removed `return` statement in l. 593 of `cyprecice/cyprecice.pxy` (please confirm that this is correct)
- Removed `import` statements in `__init__.py` since these functions do no longer exist.