### PR TITLE
set PKG_CONFIG_PATH if necessary

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,13 +61,11 @@ APPNAME = "pyprecice"
 PYTHON_BINDINGS_PATH = os.path.dirname(os.path.abspath(__file__))
 
 
-def set_pkg_config_libdir():
-    if pkgconfig.exists("libprecice"):
-        return
-    for path in os.environ["LD_LIBRARY_PATH"].split(":"):
-        os.environ["PKG_CONFIG_LIBDIR"] = path + "/pkgconfig"
-        if pkgconfig.exists("libprecice"):
-            return
+def set_pkg_config_path():
+    if not pkgconfig.exists("libprecice"):
+        os.environ["PKG_CONFIG_PATH"] = ":".join(
+            [path + "/pkgconfig" for path in os.environ["LD_LIBRARY_PATH"].split(":")]
+        )
 
 
 def get_extensions(is_test):
@@ -79,7 +77,7 @@ def get_extensions(is_test):
     bindings_sources = [os.path.join(PYTHON_BINDINGS_PATH, "cyprecice",
                                      "cyprecice" + ".pyx")]
 
-    set_pkg_config_libdir()
+    set_pkg_config_path()
 
     compile_args += pkgconfig.cflags('libprecice').split()
 

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,15 @@ APPNAME = "pyprecice"
 PYTHON_BINDINGS_PATH = os.path.dirname(os.path.abspath(__file__))
 
 
+def set_pkg_config_libdir():
+    if pkgconfig.exists("libprecice"):
+        return
+    for path in os.environ["LD_LIBRARY_PATH"].split(":"):
+        os.environ["PKG_CONFIG_LIBDIR"] = path + "/pkgconfig"
+        if pkgconfig.exists("libprecice"):
+            return
+
+
 def get_extensions(is_test):
     compile_args = []
     link_args = []
@@ -69,6 +78,8 @@ def get_extensions(is_test):
 
     bindings_sources = [os.path.join(PYTHON_BINDINGS_PATH, "cyprecice",
                                      "cyprecice" + ".pyx")]
+
+    set_pkg_config_libdir()
 
     compile_args += pkgconfig.cflags('libprecice').split()
 


### PR DESCRIPTION
When installed in a non-system location, pkg-config is not able to find the configuration file. According to pkg-config's manual, "the default is libdir/pkgconfig:datadir/pkgconfig where libdir is the libdir where pkg-config and datadir is the datadir **where pkg-config was installed.**"

This PR sets `PKG_CONFIG_PATH` using `LD_LIBRARY_PATH` to make finding precice easier.