### PR TITLE
Release v3.0.0.0dev0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
-## latest
+## 3.0.0.0dev0
+
+* Update to API introduced in preCICE v3.0.0. https://github.com/precice/python-bindings/pull/169 https://github.com/precice/python-bindings/pull/174 https://github.com/precice/python-bindings/pull/179
 
 ## 2.5.0.2
 


### PR DESCRIPTION
Development release for easier development and switching between preCICE v3.0.0.0dev0 and older versions.