### PR TITLE
Release v2.5.0.4rc1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,11 @@
 [build-system]
 # PEP 518 - minimum build system requirements
 requires = ["setuptools", "wheel", "Cython>=0.29", "packaging", "pip>=19.0.0", "numpy", "mpi4py", "pkgconfig"]
+
+[versioneer]
+VCS = git
+style = pep440
+versionfile_source = precice/_version.py
+versionfile_build = precice/_version.py
+tag_prefix =
+parentdir_prefix = precice-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,9 @@
 requires = ["setuptools", "wheel", "Cython>=0.29", "packaging", "pip>=19.0.0", "numpy", "mpi4py", "pkgconfig"]
 
 [tool.versioneer]
-VCS = git
-style = pep440
-versionfile_source = precice/_version.py
-versionfile_build = precice/_version.py
-tag_prefix =
-parentdir_prefix = precice-
+VCS = "git"
+style = "pep440"
+versionfile_source = "precice/_version.py"
+versionfile_build = "precice/_version.py"
+tag_prefix = ""
+parentdir_prefix = "precice-"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # PEP 518 - minimum build system requirements
 requires = ["setuptools", "wheel", "Cython>=0.29", "packaging", "pip>=19.0.0", "numpy", "mpi4py", "pkgconfig"]
 
-[versioneer]
+[tool.versioneer]
 VCS = git
 style = pep440
 versionfile_source = precice/_version.py


### PR DESCRIPTION
Release to fix the failure of publishing pyprecice to PyPI: https://github.com/precice/python-bindings/actions/runs/5670753421/job/15366345896