### PR TITLE
Bugfix release v2.5.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2.5.0.4
+
+* Add `tag_prefix = v` in versioneer configuration of `setup.cfg`.
+
 ## 2.5.0.3
 
 * Update from versioneer 0.19 to 0.29.

--- a/precice/_version.py
+++ b/precice/_version.py
@@ -51,7 +51,7 @@ def get_config() -> VersioneerConfig:
     cfg = VersioneerConfig()
     cfg.VCS = "git"
     cfg.style = "pep440"
-    cfg.tag_prefix = ""
+    cfg.tag_prefix = "v"
     cfg.parentdir_prefix = "precice-"
     cfg.versionfile_source = "precice/_version.py"
     cfg.verbose = False

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,5 +17,5 @@ VCS = git
 style = pep440
 versionfile_source = precice/_version.py
 versionfile_build = precice/_version.py
-tag_prefix =
+tag_prefix = v
 parentdir_prefix = precice-


### PR DESCRIPTION
This release is necessary to resolve https://github.com/precice/python-bindings/issues/185. Versioneer was not able to get the correct version, which led to failure of deployment on PyPI.