### PR TITLE
Disable build-docker workflow on push to master

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -8,7 +8,6 @@ on:
         description: branch to build the image from
         options:
           - develop
-          - master     
   push:
     branches:
       - develop
@@ -32,15 +31,9 @@ jobs:
       - name: Set PRECICE_TAG and the TAG depending on branch
         shell: bash
         run: |
-          if [[ '${{ env.BINDINGS_REF }}' == 'master' ]]; then
-              echo "PRECICE_TAG=latest" >> "$GITHUB_ENV"
-              echo "TAG=latest" >> "$GITHUB_ENV"
-              echo "Building TAG: latest"
-          else
-              echo "PRECICE_TAG=${{ env.BINDINGS_REF }}" >> "$GITHUB_ENV"
-              echo "TAG=${{ env.BINDINGS_REF }}" >> "$GITHUB_ENV"
-              echo "Building TAG: ${{ env.BINDINGS_REF }}"
-          fi   
+          echo "PRECICE_TAG=${{ env.BINDINGS_REF }}" >> "$GITHUB_ENV"
+          echo "TAG=${{ env.BINDINGS_REF }}" >> "$GITHUB_ENV"
+          echo "Building TAG: ${{ env.BINDINGS_REF }}"
       - name: Checkout Repository
         uses: actions/checkout@v2
       - name: Set up Docker Buildx

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -12,7 +12,6 @@ on:
   push:
     branches:
       - develop
-      - master
 
 
 jobs:


### PR DESCRIPTION
This disables building the Docker image on push to master, which was first enabled in #186. This workflow was simply not triggered before, but currently fails #191.

Publishing such a Docker image is not needed for the system tests anymore.

@BenjaminRodenberg @IshaanDesai I am directly contributing to the master branch as a hotfix, since this only fixes (disables) the broken GitHub Actions workflow.