### PR TITLE
Release v3.1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## 3.1.0.0
+
+* Update the release guide https://github.com/precice/python-bindings/pull/192
+
 ## 3.0.0.0
 
 * Add Cython as build time dependency https://github.com/precice/python-bindings/pull/177

--- a/docs/ReleaseGuide.md
+++ b/docs/ReleaseGuide.md
@@ -50,4 +50,4 @@ The release of the `python-bindings` repository is made directly from a release 
 
    For more details refer to https://github.com/precice/python-bindings/issues/109 and https://github.com/python-versioneer/python-versioneer/issues/217.
 
-8. Update Spack package (refer to `python-bindings/spack/README.md`).
+9. Update Spack package (refer to `python-bindings/spack/README.md`).

--- a/docs/ReleaseGuide.md
+++ b/docs/ReleaseGuide.md
@@ -13,23 +13,29 @@ The release of the `python-bindings` repository is made directly from a release 
     * `CHANGELOG.md` on `python-bindings-v2.1.1.1`.
     * There is no need to bump the version anywhere else, since we use the [python-versioneer](https://github.com/python-versioneer/python-versioneer/) for maintaining the version everywhere else.
 
-4. [Draft a New Release](https://github.com/precice/python-bindings/releases/new) in the `Releases` section of the repository page in a web browser. The release tag needs to be the exact version number (i.e.`v2.1.1.1` or `v2.1.1.1rc1`, compare to [existing tags](https://github.com/precice/python-bindings/tags)). Use `@target:master`. Release title is also the version number (i.e. `v2.1.1.1` or `v2.1.1.1rc1`, compare to [existing releases](https://github.com/precice/python-bindings/tags)).
+4. [Draft a New Release](https://github.com/precice/python-bindings/releases/new) in the `Releases` section of the repository page in a web browser.
 
-    * *Note:* We use the [python-versioneer](https://github.com/python-versioneer/python-versioneer/) for maintaining the version. Therefore the tag directly defines the version in all relevant places.
-    * *Note:* If it is a pre-release then the option *This is a pre-release* needs to be selected at the bottom of the page. Use `@target:python-bindings-v2.1.1.1` for a pre-release, since we will never merge a pre-release into master.
-    * Use the `Auto-generate release notes` feature. See, for example, https://github.com/precice/python-bindings/releases/tag/v2.3.0.1
+    * The release tag needs to be the exact version number (i.e.`v2.1.1.1` or `v2.1.1.1rc1`, compare to [existing tags](https://github.com/precice/python-bindings/tags)).
+    * If this is a stable release, use `@target:master`. If this is a pre-release, use `@target:python-bindings-v2.1.1.1`. If you are making a pre-release, **directly skip to the [pre-release](#pre-release) section below**.
+    * Release title is also the version number (i.e. `v2.1.1.1` or `v2.1.1.1rc1`, compare to [existing releases](https://github.com/precice/python-bindings/tags)).
 
-    a) If a pre-release is made: Directly hit the "Publish release" button in your Release Draft. Now you can check the artifacts (e.g. release on [PyPI](https://pypi.org/project/pyprecice/#history)) of the release. *Note:* As soon as a new tag is created github actions will take care of deploying the new version on PyPI using [this workflow](https://github.com/precice/python-bindings/actions?query=workflow%3A%22Upload+Python+Package%22).
+5. As soon as one approving review is made, merge the release PR (from `python-bindings-v2.1.1.1`) into `master`.
 
-    b) If this is a "real" release: As soon as one approving review is made, merge the release PR (from `python-bindings-v2.1.1.1`) into `master`.
+6. Merge `master` into `develop` for synchronization of `develop`.
 
-5. Merge `master` into `develop` for synchronization of `develop`.
+7. If everything is in order up to this point then the new version can be released by hitting the "Publish release" button in your release Draft. This will create the corresponding tag and trigger [publishing the release to PyPI](https://github.com/precice/python-bindings/actions?query=workflow%3A%22Upload+Python+Package%22).
 
-6. If everything is in order up to this point then the new version can be released by hitting the "Publish release" button in your Release Draft. This will create the corresponding tag and trigger [publishing the release to PyPI](https://github.com/precice/python-bindings/actions?query=workflow%3A%22Upload+Python+Package%22).
+8. Now there exists be a tag corresponding to the release on `master`. Re-run the [docker release workflow `build-docker.yml` via dispatch]([https://github.com/precice/fenics-adapter/actions/workflows/build-docker.yml](https://github.com/precice/python-bindings/actions/workflows/build-docker.yml)) such that the correct version is picked up by `versioneer`. Check the version in the container via `docker pull precice/pythonbindings`, then `docker run -ti precice/pythonbindings`, and inside the container `$ python3 -c "import precice; print(precice.__version__)"`. ⚠️ There is an open issue that needs fixing https://github.com/precice/python-bindings/issues/195 ⚠️
 
-7. Now there exists be a tag corresponding to the release on `master`. Re-run the [docker release workflow `build-docker.yml` via dispatch]([https://github.com/precice/fenics-adapter/actions/workflows/build-docker.yml](https://github.com/precice/python-bindings/actions/workflows/build-docker.yml)) such that the correct version is picked up by `versioneer`. Check the version in the container via `docker pull precice/pythonbindings`, then `docker run -ti precice/pythonbindings`, and inside the container `$ python3 -c "import precice; print(precice.__version__)"`. ⚠️ There is an open issue that needs fixing https://github.com/precice/python-bindings/issues/195 ⚠️
+9. Add an empty commit (details https://github.com/precice/python-bindings/issues/109) on master by running the steps:
 
-8. Add an empty commit on master via `git checkout master`, then `git commit --allow-empty -m "post-tag bump"`. Check that everything is in order via `git log`. Important: The `tag` and `origin/master` should not point to the same commit. For example:
+    ```bash
+    git checkout master
+    git commit --allow-empty -m "post-tag bump"
+    git push
+    ```
+
+    Check that everything is in order via `git log`. Important: The `tag` and `origin/master` should not point to the same commit. For example:
 
    ```bash
    commit 44b715dde4e3194fa69e61045089ca4ec6925fe3 (HEAD -> master, origin/master)
@@ -50,4 +56,8 @@ The release of the `python-bindings` repository is made directly from a release 
 
    For more details refer to https://github.com/precice/python-bindings/issues/109 and https://github.com/python-versioneer/python-versioneer/issues/217.
 
-9. Update Spack package (refer to `python-bindings/spack/README.md`).
+10. *Temporarily not maintained* Update Spack package (refer to `python-bindings/spack/README.md`).
+
+## Pre-release
+
+After creating the branch and drafting a release, directly hit the "Publish release" button in your Release Draft. Please note that the release branch is not merged into the master branch during a pre-release. Merging is done only for the stable release. You can check the pre-release artifacts (e.g. release on [PyPI](https://pypi.org/project/pyprecice/#history)) of the release. No further action is required for a pre-release.

--- a/docs/ReleaseGuide.md
+++ b/docs/ReleaseGuide.md
@@ -27,7 +27,9 @@ The release of the `python-bindings` repository is made directly from a release 
 
 6. If everything is in order up to this point then the new version can be released by hitting the "Publish release" button in your Release Draft. This will create the corresponding tag and trigger [publishing the release to PyPI](https://github.com/precice/python-bindings/actions?query=workflow%3A%22Upload+Python+Package%22).
 
-7. Add an empty commit on master via `git checkout master`, then `git commit --allow-empty -m "post-tag bump"`. Check that everything is in order via `git log`. Important: The `tag` and `origin/master` should not point to the same commit. For example:
+7. Now there exists be a tag corresponding to the release on `master`. Re-run the [docker release workflow `build-docker.yml` via dispatch]([https://github.com/precice/fenics-adapter/actions/workflows/build-docker.yml](https://github.com/precice/python-bindings/actions/workflows/build-docker.yml)) such that the correct version is picked up by `versioneer`. Check the version in the container via `docker pull precice/pythonbindings`, then `docker run -ti precice/pythonbindings`, and inside the container `$ python3 -c "import precice; print(precice.__version__)"`. ⚠️ There is an open issue that needs fixing https://github.com/precice/python-bindings/issues/195 ⚠️
+
+8. Add an empty commit on master via `git checkout master`, then `git commit --allow-empty -m "post-tag bump"`. Check that everything is in order via `git log`. Important: The `tag` and `origin/master` should not point to the same commit. For example:
 
    ```bash
    commit 44b715dde4e3194fa69e61045089ca4ec6925fe3 (HEAD -> master, origin/master)

--- a/tools/releasing/packaging/docker/Dockerfile
+++ b/tools/releasing/packaging/docker/Dockerfile
@@ -16,16 +16,7 @@ RUN apt-get -qq update && apt-get -qq install \
     pkg-config && \
     rm -rf /var/lib/apt/lists/*
 
-# Setup passwordless sudo
-RUN echo "ALL            ALL = (ALL) NOPASSWD: ALL" >> /etc/sudoers
-
-# Switch to the user precice
 USER precice
-WORKDIR /home/precice
-ENV USER=precice
-
-# Use bash instead of default sh
-SHELL ["/bin/bash", "-c"]
 
 # Upgrade pip to newest version (pip version from 18.04 apt-get is outdated)
 RUN python3 -m pip install --user --upgrade pip

--- a/tools/releasing/packaging/docker/Dockerfile
+++ b/tools/releasing/packaging/docker/Dockerfile
@@ -16,16 +16,6 @@ RUN apt-get -qq update && apt-get -qq install \
     pkg-config && \
     rm -rf /var/lib/apt/lists/*
 
-## Needed, because precice/precice:latest does not create a user? See also https://github.com/precice/precice/pull/1090, https://github.com/precice/python-bindings/issues/191
-## ------>
-# Create user precice
-ARG uid=1000
-ARG gid=1000
-RUN groupadd -g ${gid} precice \
-    && useradd -u ${uid} -g ${gid} -m -s /bin/bash precice \
-    && sudo usermod -a -G sudo precice
-## <-----
-
 # Setup passwordless sudo
 RUN echo "ALL            ALL = (ALL) NOPASSWD: ALL" >> /etc/sudoers
 

--- a/tools/releasing/packaging/docker/Dockerfile
+++ b/tools/releasing/packaging/docker/Dockerfile
@@ -16,15 +16,15 @@ RUN apt-get -qq update && apt-get -qq install \
     pkg-config && \
     rm -rf /var/lib/apt/lists/*
 
-## Needed, if base image does not create a user? See also https://github.com/precice/precice/pull/1090
-## At the moment: precice/precice:latest does not create a user, but benjaminrodenberg/precice:develop creates a user
+## Needed, because precice/precice:latest does not create a user? See also https://github.com/precice/precice/pull/1090, https://github.com/precice/python-bindings/issues/191
 ## ------>
 # Create user precice
-# ARG uid=1000
-# ARG gid=1000
-# RUN groupadd -g ${gid} precice \
-#     && useradd -u ${uid} -g ${gid} -m -s /bin/bash precice \
-#     && sudo usermod -a -G sudo precice
+ARG uid=1000
+ARG gid=1000
+RUN groupadd -g ${gid} precice \
+    && useradd -u ${uid} -g ${gid} -m -s /bin/bash precice \
+    && sudo usermod -a -G sudo precice
+## <-----
 
 # Setup passwordless sudo
 RUN echo "ALL            ALL = (ALL) NOPASSWD: ALL" >> /etc/sudoers
@@ -36,7 +36,6 @@ ENV USER=precice
 
 # Use bash instead of default sh
 SHELL ["/bin/bash", "-c"]
-## <-----
 
 # Upgrade pip to newest version (pip version from 18.04 apt-get is outdated)
 RUN python3 -m pip install --user --upgrade pip


### PR DESCRIPTION
Compatibility release for preCICE [v3.1.0](https://github.com/precice/precice/releases/tag/v3.1.0)