### PR TITLE
Release v3.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## latest
+
+* Fix NumPy include order to not conflict with system NumPy and the one installed via pip https://github.com/precice/python-bindings/pull/204
+
 ## v3.1.0
 
 * Change versioning scheme https://github.com/precice/python-bindings/pull/199

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## latest
+## v3.1.1
 
 * Fix NumPy include order to not conflict with system NumPy and the one installed via pip https://github.com/precice/python-bindings/pull/204
 

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ def get_extensions(is_test):
     compile_args = []
     link_args = []
     compile_args.append("-std=c++17")
-    compile_args.append("-I{}".format(numpy.get_include()))
+    include_dirs = [numpy.get_include()]
 
     bindings_sources = [os.path.join(PYTHON_BINDINGS_PATH, "cyprecice",
                                      "cyprecice" + ".pyx")]
@@ -84,6 +84,7 @@ def get_extensions(is_test):
             sources=bindings_sources,
             libraries=[],
             language="c++",
+            include_dirs=include_dirs,
             extra_compile_args=compile_args,
             extra_link_args=link_args
         )


### PR DESCRIPTION
This is a bugfix release of the bindings. The order in which NumPy is included in the build setup is changed to prevent a conflict between the system installed NumPy, and the NumPy installed via pip.