### PR TITLE
Require setuptools>=61

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## latest
+
+* Require setuptools >= 61 to guarantee that pyproject.toml is used https://github.com/precice/python-bindings/pull/207
+* Fix CI pipeline for spack https://github.com/precice/python-bindings/pull/206
+
 ## v3.1.1
 
 * Fix NumPy include order to not conflict with system NumPy and the one installed via pip https://github.com/precice/python-bindings/pull/204

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
 # PEP 518 - minimum build system requirements
-requires = ["setuptools", "wheel", "Cython>=0.29", "packaging", "pip>=19.0.0", "numpy", "mpi4py", "pkgconfig"]
+requires = ["setuptools>=61", "wheel", "Cython>=0.29", "packaging", "pip>=19.0.0", "numpy", "mpi4py", "pkgconfig"]

--- a/setup.py
+++ b/setup.py
@@ -5,17 +5,6 @@ import versioneer
 
 uses_pip = "pip" in __file__
 
-# check whether pip is used for installation. If pip is not used, dependencies defined in pyproject.toml might be
-# missing.
-if not uses_pip:
-    warnings.warn(
-        "It looks like you are not using pip for installation. Installing the package via 'pip3 install "
-        "--user .' is recommended. You can still use 'python3 setup.py install --user', if you want and if "
-        "the bindings work correctly, you do not have to worry. However, if you face problems during "
-        "installation or running pyprecice, this means that you have to make sure that all dependencies are "
-        "installed correctly and repeat the installation of pyprecice. Refer to pyproject.toml for a list "
-        "of dependencies.")
-
 if uses_pip:
     # If installed with pip we need to check its version
     try:
@@ -45,7 +34,6 @@ if uses_pip:
                 " flag.".format(pip.__version__))
 
 from setuptools import setup
-from setuptools import Command
 from setuptools.command.test import test
 from setuptools.command.install import install
 from Cython.Distutils.extension import Extension

--- a/spack/repo/packages/py-pyprecice/package.py
+++ b/spack/repo/packages/py-pyprecice/package.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
@@ -58,7 +58,7 @@ class PyPyprecice(PythonPackage):
         depends_on("precice@" + ver, when="@" + ver)
 
     depends_on("python@3:", type=("build", "link", "run"))
-    depends_on("py-setuptools", type="build")
+    depends_on("py-setuptools@61:", type="build")
     depends_on("py-numpy", type=("build", "link", "run"))
     depends_on("py-mpi4py", type=("build", "run"))
     depends_on("py-cython@0.29:", type="build")


### PR DESCRIPTION
Requiring setuptools>=61 allows us to remove a noisy warning that always shows up when building with spack. It also allows us to simplify the `setup.py`. Setuptools>=61 guarantees that pyproject.toml is used.