### PR TITLE
Release v2.5.1.0

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,7 +13,7 @@ jobs:
     needs: [setup_test]
     runs-on: ubuntu-latest
     container:
-      image: precice/precice:latest
+      image: precice/precice:2.5.1
       options: --user root
     steps:
       - name: Checkout Repository
@@ -37,7 +37,7 @@ jobs:
     name: Run setup install
     runs-on: ubuntu-latest
     container:
-      image: precice/precice:latest
+      image: precice/precice:2.5.1
       options: --user root
     steps:
       - name: Checkout Repository
@@ -62,7 +62,7 @@ jobs:
     needs: [setup_install]
     runs-on: ubuntu-latest
     container:
-      image: precice/precice:latest
+      image: precice/precice:2.5.1
       options: --user root
     steps:
       - name: Checkout Repository
@@ -119,7 +119,7 @@ jobs:
     needs: [setup_test]
     runs-on: ubuntu-latest
     container:
-      image: precice/precice:latest
+      image: precice/precice:2.5.1
       options: --user root
     steps:
       - name: Checkout Repository
@@ -140,7 +140,7 @@ jobs:
     needs: [setup_install, setup_test]
     runs-on: ubuntu-latest
     container:
-      image: precice/precice:latest
+      image: precice/precice:2.5.1
       options: --user root
     steps:
       - name: Checkout Repository

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -1,10 +1,19 @@
 name: Update docker image
 
 on:
-  workflow_dispatch:      # Trigger by hand from the UI
+  workflow_dispatch: # Trigger by hand from the UI
+    inputs:
+      branch:
+        type: choice
+        description: branch to build the image from
+        options:
+          - develop
+          - master     
   push:
     branches:
       - develop
+      - master
+
 
 jobs:
   build-and-release-docker-image:
@@ -13,10 +22,26 @@ jobs:
     env:
         docker_username: precice
     steps:
-      - name: Get branch name
-        if: github.event_name != 'pull_request'
+      - name: Set branch name for manual triggering
+        if: github.event_name == 'workflow_dispatch'
         shell: bash
-        run: echo "branch=$(echo ${GITHUB_REF#refs/heads/} | tr / -)" >> $GITHUB_ENV    
+        run: echo "BINDINGS_REF=${{ inputs.branch }}" >> $GITHUB_ENV
+      - name: Set branch name for "on pull request" triggering
+        if: github.event_name != 'pull_request' && github.event_name != 'workflow_dispatch'
+        shell: bash
+        run: echo "BINDINGS_REF=${{ github.ref_name }}" >> $GITHUB_ENV
+      - name: Set PRECICE_TAG and the TAG depending on branch
+        shell: bash
+        run: |
+          if [[ '${{ env.BINDINGS_REF }}' == 'master' ]]; then
+              echo "PRECICE_TAG=latest" >> "$GITHUB_ENV"
+              echo "TAG=latest" >> "$GITHUB_ENV"
+              echo "Building TAG: latest"
+          else
+              echo "PRECICE_TAG=${{ env.BINDINGS_REF }}" >> "$GITHUB_ENV"
+              echo "TAG=${{ env.BINDINGS_REF }}" >> "$GITHUB_ENV"
+              echo "Building TAG: ${{ env.BINDINGS_REF }}"
+          fi   
       - name: Checkout Repository
         uses: actions/checkout@v2
       - name: Set up Docker Buildx
@@ -31,6 +56,7 @@ jobs:
         with:
           push: true
           file: "./tools/releasing/packaging/docker/Dockerfile"
-          tags: ${{ env.docker_username }}/python-bindings:${{ env.branch }},${{ env.docker_username }}/python-bindings:latest
+          tags: ${{ env.docker_username }}/python-bindings:${{ env.TAG }}
           build-args: |
-            branch=${{ env.branch }}
+            PRECICE_TAG=${{ env.PRECICE_TAG }}
+            PYTHON_BINDINGS_REF=${{ env.BINDINGS_REF }}

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -8,7 +8,6 @@ on:
         description: branch to build the image from
         options:
           - develop
-          - master     
   push:
     branches:
       - develop
@@ -32,15 +31,9 @@ jobs:
       - name: Set PRECICE_TAG and the TAG depending on branch
         shell: bash
         run: |
-          if [[ '${{ env.BINDINGS_REF }}' == 'master' ]]; then
-              echo "PRECICE_TAG=latest" >> "$GITHUB_ENV"
-              echo "TAG=latest" >> "$GITHUB_ENV"
-              echo "Building TAG: latest"
-          else
-              echo "PRECICE_TAG=${{ env.BINDINGS_REF }}" >> "$GITHUB_ENV"
-              echo "TAG=${{ env.BINDINGS_REF }}" >> "$GITHUB_ENV"
-              echo "Building TAG: ${{ env.BINDINGS_REF }}"
-          fi   
+          echo "PRECICE_TAG=${{ env.BINDINGS_REF }}" >> "$GITHUB_ENV"
+          echo "TAG=${{ env.BINDINGS_REF }}" >> "$GITHUB_ENV"
+          echo "Building TAG: ${{ env.BINDINGS_REF }}"
       - name: Checkout Repository
         uses: actions/checkout@v2
       - name: Set up Docker Buildx

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -12,7 +12,6 @@ on:
   push:
     branches:
       - develop
-      - master
 
 
 jobs:

--- a/.github/workflows/build-env.yml
+++ b/.github/workflows/build-env.yml
@@ -2,6 +2,12 @@ name: Update build environment
 
 on:
   workflow_dispatch:      # Trigger by hand from the UI
+    inputs:
+      tag:
+        description: 'tag for docker image'
+        required: true
+        default: 'latest'
+        type: string
   schedule:
     - cron: '0 0 * * 0'   # Schedule it every Sunday
 
@@ -24,5 +30,5 @@ jobs:
         with:
           push: true
           context: .
-          file: spack/ci-spack-pyprecice-deps-2204.dockerfile
-          tags: precice/ci-spack-pyprecice-deps-2204
+          file: spack/ci-spack-pyprecice-deps-2404.dockerfile
+          tags: precice/ci-spack-pyprecice-deps-2404:${{ inputs.tag }}

--- a/.github/workflows/build-spack.yml
+++ b/.github/workflows/build-spack.yml
@@ -14,7 +14,7 @@
 #     name: build_spack
 #     runs-on: ubuntu-latest
 #     timeout-minutes: 15
-#     container: precice/ci-spack-pyprecice-deps-2204
+#     container: precice/ci-spack-pyprecice-deps-2404
 #     defaults:
 #       run:
 #         shell: "bash --login -eo pipefail {0}"

--- a/.github/workflows/build-spack.yml
+++ b/.github/workflows/build-spack.yml
@@ -1,35 +1,35 @@
-# name: Build Spack
-# on:
-#   push:
-#     branches:
-#       - "*"
-#   pull_request:
-#     branches:
-#       - "*"
-#   schedule:
-#     - cron: '0 4 * * 1'   # Schedule it every Sunday
-#
-# jobs:
-#   build_spack:
-#     name: build_spack
-#     runs-on: ubuntu-latest
-#     timeout-minutes: 15
-#     container: precice/ci-spack-pyprecice-deps-2404
-#     defaults:
-#       run:
-#         shell: "bash --login -eo pipefail {0}"
-#     steps:
-#       - name: Checkout Repository
-#         uses: actions/checkout@v2
-#       - name: Move Package Script
-#         run: |
-#           cp -r spack/repo/packages/py-pyprecice/ /py-pyprecice-repo/packages/
-#       - name: Try to build py-pyprecice with spack and test it
-#         run: |
-#           . /opt/spack/share/spack/setup-env.sh
-#           spack env activate ci && spack arch
-#           spack remove py-pyprecice
-#           spack add pyprecice.test.py-pyprecice@develop && spack develop pyprecice.test.py-pyprecice@develop
-#           spack install && spack find
-#           spack load py-pyprecice
-#           BINDINGS_VERSION=$(python3 -c "import precice; print(precice.__version__)") && echo "Installed version of bindings is ${BINDINGS_VERSION}"
+name: Build Spack
+on:
+  push:
+    branches:
+      - "*"
+  pull_request:
+    branches:
+      - "*"
+  schedule:
+    - cron: '0 4 * * 1'   # Schedule it every Sunday
+
+jobs:
+  build_spack:
+    name: build_spack
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    container: precice/ci-spack-pyprecice-deps-2404
+    defaults:
+      run:
+        shell: "bash --login -eo pipefail {0}"
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+      - name: Move Package Script
+        run: |
+          cp -r spack/repo/packages/py-pyprecice/ /py-pyprecice-repo/packages/
+      - name: Try to build py-pyprecice with spack and test it
+        run: |
+          . /opt/spack/share/spack/setup-env.sh
+          spack env activate ci && spack arch
+          spack remove py-pyprecice
+          spack add pyprecice.test.py-pyprecice@develop && spack develop pyprecice.test.py-pyprecice@develop
+          spack install && spack find
+          spack load py-pyprecice
+          BINDINGS_VERSION=$(python3 -c "import precice; print(precice.__version__)") && echo "Installed version of bindings is ${BINDINGS_VERSION}"

--- a/.github/workflows/build-spack.yml
+++ b/.github/workflows/build-spack.yml
@@ -14,7 +14,7 @@ jobs:
     name: build_spack
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    container: precice/ci-spack-pyprecice-deps-2404
+    container: precice/ci-spack-pyprecice-deps-2404:2.5.1.0
     defaults:
       run:
         shell: "bash --login -eo pipefail {0}"

--- a/.github/workflows/build-spack.yml
+++ b/.github/workflows/build-spack.yml
@@ -29,7 +29,7 @@ jobs:
           . /opt/spack/share/spack/setup-env.sh
           spack env activate ci && spack arch
           spack remove py-pyprecice
-          spack add pyprecice.test.py-pyprecice@develop && spack develop pyprecice.test.py-pyprecice@develop
+          spack add pyprecice.test.py-pyprecice@2.5.1.0 && spack develop pyprecice.test.py-pyprecice@2.5.1.0
           spack install && spack find
           spack load py-pyprecice
           BINDINGS_VERSION=$(python3 -c "import precice; print(precice.__version__)") && echo "Installed version of bindings is ${BINDINGS_VERSION}"

--- a/.github/workflows/check-markdown.yml
+++ b/.github/workflows/check-markdown.yml
@@ -1,0 +1,14 @@
+name: Lint docs
+on: [push, pull_request]
+jobs:
+  check_md:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+      - name: Lint markdown files (markdownlint)
+        uses: articulate/actions-markdownlint@v1
+        with:
+          config: .markdownlint.json
+          files: '.'
+          ignore: changelog-entries

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -27,8 +27,8 @@ jobs:
           pkgconfig
     - name: Build and publish
       env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
       run: |
         python setup.py sdist
         twine upload dist/*

--- a/.github/workflows/run-solverdummy.yml
+++ b/.github/workflows/run-solverdummy.yml
@@ -11,7 +11,7 @@ jobs:
     name: Run solverdummies
     runs-on: ubuntu-latest
     container:
-      image: precice/precice:latest
+      image: precice/precice:2.5.1
       options: --user root
     steps:
       - name: Checkout Repository

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,7 @@
+{
+    "MD013": false,
+    "MD014": false,
+    "MD024": false,
+    "MD034": false,
+    "MD033": false
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2.5.1.0
+
+* Backported trivial changes from v3. https://github.com/precice/python-bindings/issues/203
+
 ## 2.5.0.4
 
 * Add `tag_prefix = v` in versioneer configuration of `setup.cfg`.

--- a/README.md
+++ b/README.md
@@ -1,17 +1,16 @@
-⚠️ The latest version of the documentation for the python bindings can be found on [precice.org](https://precice.org/installation-bindings-python.html). The information from this `README` is currently under revision and will be moved ⚠️
+# Python language bindings for the C++ library preCICE
 
-Python language bindings for the C++ library preCICE
-----------------------------------------------------
+⚠️ The latest version of the documentation for the python bindings can be found on [precice.org](https://precice.org/installation-bindings-python.html). The information from this `README` is currently under revision and will be moved ⚠️
 
 [![Upload Python Package](https://github.com/precice/python-bindings/workflows/Upload%20Python%20Package/badge.svg?branch=master)](https://pypi.org/project/pyprecice/)
 
 This package provides python language bindings for the C++ library [preCICE](https://github.com/precice/precice). Note that the first three digits of the version number of the bindings indicate the preCICE version that the bindings support. The last digit represents the version of the bindings. Example: `v2.0.0.1` and `v2.0.0.2` of the bindings represent versions `1` and `2` of the bindings that are compatible with preCICE `v2.0.0`.
 
-# User documentation
+## User documentation
 
 Please refer to [the preCICE documentation](https://www.precice.org/installation-bindings-python.html) for information on how to install and use the python bindings. Information below is intended for advanced users and developers.
 
-# Required dependencies
+## Required dependencies
 
 **preCICE**: Refer to [the preCICE documentation](https://precice.org/installation-overview.html) for information on building and installation.
 
@@ -19,143 +18,154 @@ Please refer to [the preCICE documentation](https://www.precice.org/installation
 
 **MPI**: `mpi4py` requires MPI to be installed on your system.
 
-# Installing the package
+## Installing the package
 
 We recommend using pip3 (version 19.0.0 or newer required) for the sake of simplicity. You can check your pip3 version via `pip3 --version`. To update pip3, use the following line:
 
-```
+```bash
 $ pip3 install --user --upgrade pip
 ```
 
-## Using pip3
+### Using pip3
 
-### preCICE system installs
+#### preCICE system installs
 
 For system installs of preCICE, installation works out of the box. There are different ways how pip can be used to install pyprecice. pip will fetch cython and other build-time dependencies, compile the bindings and finally install the package pyprecice.
 
 * (recommended) install [pyprecice from PyPI](https://pypi.org/project/pyprecice/)
 
-  ```
+  ```bash
   $ pip3 install --user pyprecice
   ```
 
 * provide the link to this repository to pip (replace `<branch>` with the branch you want to use, preferably `master` or `develop`)
 
-  ```
+  ```bash
   $ pip3 install --user https://github.com/precice/python-bindings/archive/<branch>.zip
   ```
 
 * if you already cloned this repository, execute the following command from this directory:
 
-  ```
+  ```bash
   $ pip3 install --user .
   ```
+
   *note the dot at the end of the line*
 
-### preCICE at custom location (setting PATHS)
+#### preCICE at custom location (setting PATHS)
 
 If preCICE (the C++ library) was installed in a custom prefix, or only built but not installed at all, you have to extend the following environment variables:
 
-- `LIBRARY_PATH`, `LD_LIBRARY_PATH` to the library location, or `$prefix/lib`
-- `CPATH` either to the `src` directory or the `$prefix/include`
+* `LIBRARY_PATH`, `LD_LIBRARY_PATH` to the library location, or `$prefix/lib`
+* `CPATH` either to the `src` directory or the `$prefix/include`
 
 The preCICE documentation provides more informaiton on [linking preCICE](https://precice.org/installation-linking.html).
 
-## Using Spack
+### Using Spack
 
 You can also install the python language bindings for preCICE via Spack by installing the Spack package `py-pyprecice`. Refer to [our installation guide for preCICE via Spack](https://precice.org/installation-spack.html) for getting started with Spack.
 
-## Using setup.py
+### Using setup.py
 
-### preCICE system installs
+#### preCICE system installs
 
 In this directory, execute:
-```
+
+```bash
 $ python3 setup.py install --user
 ```
 
-### preCICE at custom location (setting PATHS)
+#### preCICE at custom location (setting PATHS)
 
 see above. Then run
-```
+
+```bash
 $ python3 setup.py install --user
 ```
 
-### preCICE at custom location (explicit include path, library path)
+#### preCICE at custom location (explicit include path, library path)
 
 1. Install cython and other dependencies via pip3
-   ```
+
+   ```bash
    $ pip3 install --user setuptools wheel cython packaging numpy
    ```
+
 2. Open terminal in this folder.
 3. Build the bindings
-   ```
+
+   ```bash
    $ python3 setup.py build_ext --include-dirs=$PRECICE_ROOT/src --library-dirs=$PRECICE_ROOT/build/last
    ```
 
-  **Options:**
-  - `--include-dirs=`, default: `''` 
-    Path to the headers of preCICE, point to the sources `$PRECICE_ROOT/src`, or the your custom install prefix `$prefix/include`.
-  
-  **NOTES:**
-  
-  - If you have built preCICE using CMake, you can pass the path to the CMake binary directory using `--library-dirs`.
-  - It is recommended to use preCICE as a shared library here.
+   **Options:**
+   * `--include-dirs=`, default: `''`
+     Path to the headers of preCICE, point to the sources `$PRECICE_ROOT/src`, or the your custom install prefix `$prefix/include`.
+
+   **NOTES:**
+
+   * If you have built preCICE using CMake, you can pass the path to the CMake binary directory using `--library-dirs`.
+   * It is recommended to use preCICE as a shared library here.
 
 4. Install the bindings
-   ```
+
+   ```bash
    $ python3 setup.py install --user
    ```
 
-5. Clean-up _optional_
-   ```
+5. Clean-up *optional*
+
+   ```bash
    $ python3 setup.py clean --all
    ```
 
-# Test the installation
+## Test the installation
 
 Update `LD_LIBRARY_PATH` such that python can find `precice.so`
 
-```
+```bash
 $ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PRECICE_ROOT/build/last
 ```
 
 Run the following to test the installation:
 
-```
+```bash
 $ python3 -c "import precice"
 ```
 
-## Unit tests
+### Unit tests
 
-1. Clean-up __mandatory__ (because we must not link against the real `precice.so`, but we use a mocked version)
-   ```
+1. Clean-up **mandatory** (because we must not link against the real `precice.so`, but we use a mocked version)
+
+   ```bash
    $ python3 setup.py clean --all
    ```
 
 2. Set `CPLUS_INCLUDE_PATH` (we cannot use `build_ext` and the `--include-dirs` option here)
-   ```
+
+   ```bash
    $ export CPLUS_INCLUDE_PATH=$CPLUS_INCLUDE_PATH:$PRECICE_ROOT/src
    ```
 
 3. Run tests with
-   ```
+
+   ```bash
    $ python3 setup.py test
    ```
 
-# Usage
+## Usage
 
-You can find the documentation of the implemented interface in the file `precice.pyx`. For an example of how `pyprecice` can be used please refer to the [1D elastic tube example](https://precice.org/tutorials-elastic-tube-1d.html#python). 
+You can find the documentation of the implemented interface in the file `precice.pyx`. For an example of how `pyprecice` can be used please refer to the [1D elastic tube example](https://precice.org/tutorials-elastic-tube-1d.html#python).
 
 **Note** The python package that is installed is called `pyprecice`. It provides the python module `precice` that can be use in your code via `import precice`, for example.
 
-# Troubleshooting & miscellaneous
+## Troubleshooting & miscellaneous
 
 ### preCICE is not found
 
 The following error shows up during installation, if preCICE is not found:
 
-```
+```bash
   /tmp/pip-install-d_fjyo1h/pyprecice/precice.cpp:643:10: fatal error: precice/SolverInterface.hpp: No such file or directory
     643 | #include "precice/SolverInterface.hpp"
         |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -178,7 +188,7 @@ In case the compilation fails with `shared_ptr.pxd not found` messages, check if
 
 ### `Python.h` missing
 
-```
+```bash
 $ python3 -m pip install pyprecice
 Collecting pyprecice
 ...
@@ -187,14 +197,14 @@ Collecting pyprecice
   error: command 'x86_64-linux-gnu-gcc' failed with exit status 1
 
   ----------------------------------------
-  Failed building wheel for pyprecice 
+  Failed building wheel for pyprecice
 ```
 
 Please try to install `python3-dev`. E.g. via `apt install python3-dev`. Please make sure that you use the correct version (e.g. `python3.5-dev` or `python3.6-dev`). You can check your version via `python3 --version`.
 
 ### `libprecice.so` is not found at runtime
 
-```
+```bash
 $ python3 -c "import precice"
 Traceback (most recent call last):
   File "<stdin>", line 1, in <module>
@@ -216,43 +226,53 @@ If you want to use the old experimental python bindings (released with preCICE v
 This guide provides steps to install python bindings for precice-1.6.1 for a conda environment Python 2.7.17 on the CoolMUC. Note that preCICE no longer supports Python 2 after v1.4.0. Hence, some modifications to the python setup code was necessary. Most steps are similar if not identical to the basic guide without petsc or python above. This guide assumes that the Eigen dependencies have already been installed.
 
 Load the prerequisite libraries:
-```
+
+```bash
 module load gcc/7
 module unload mpi.intel
 module load mpi.intel/2018_gcc
 module load cmake/3.12.1
 ```
+
 At the time of this writing `module load boost/1.68.0` is no longer available. Instead
-boost 1.65.1 was installed per the `boost and yaml-cpp` guide above. 
+boost 1.65.1 was installed per the `boost and yaml-cpp` guide above.
 
 In order to have the right python dependencies, a packaged conda environment was transferred to
 SuperMUC. The following dependencies were installed:
-- numpy
-- mpi4py
+
+* numpy
+* mpi4py
 
 With the python environment active, we have to feed the right python file directories to the cmake command.
 Note that -DPYTHON_LIBRARY expects a python shared library. You can likely modify the version to fit what is required.
-```
+
+```bash
 mkdir build && cd build
 cmake -DBUILD_SHARED_LIBS=ON -DPRECICE_PETScMapping=OFF -DPRECICE_PythonActions=ON -DCMAKE_INSTALL_PREFIX=/path/to/precice -DCMAKE_BUILD_TYPE=Debug .. -DPYTHON_INCLUDE_DIR=$(python -c "from distutils.sysconfig import get_python_inc; print(get_python_inc())")  -DPYTHON_LIBRARY=$(python -c "import distutils.sysconfig as sysconfig; print(sysconfig.get_config_var('LIBDIR')+'/libpython2.7.so')") -DNumPy_INCLUDE_DIR=$(python -c "import numpy; print(numpy.get_include())")
 make -j 12
 make install
 ```
+
 After installing, make sure you add the preCICE installation paths to your `.bashrc`, so that other programs can find it:
-```
+
+```bash
 export PRECICE_ROOT="path/to/precice_install"
 export PKG_CONFIG_PATH="path/to/precice_install/lib/pkgconfig:${PKG_CONFIG_PATH}"
 export CPLUS_INCLUDE_PATH="path/to/precice_install/include:${CPLUS_INCLUDE_PATH}"
 export LD_LIBRARY_PATH="path/to/precice_install/lib:${LD_LIBRARY_PATH}"
 ```
+
 Then, navigate to the python_future bindings script.
-```
+
+```bash
 cd /path/to/precice/src/precice/bindings/python_future
 ```
+
 Append the following to the head of the file to allow Python2 to run Python3 code. Note that
-importing `unicode_literals` from `future` will cause errors in `setuptools` methods as string literals 
+importing `unicode_literals` from `future` will cause errors in `setuptools` methods as string literals
 in code are interpreted as `unicode` with this import.
-```
+
+```python
 from __future__ import (absolute_import, division,
                         print_function)
 from builtins import (
@@ -261,14 +281,18 @@ from builtins import (
          pow, round, super,
          filter, map, zip)
 ```
+
 Modify `mpicompiler_default = "mpic++"` to `mpicompiler_default = "mpicxx"` in line 100.
 Run the setup file using the default Python 2.7.17.
-```
+
+```bash
 python setup.py install --user
 ```
+
 </details>
 
 ### ValueError while importing preCICE
+
 If you face the error:
 
 ```bash
@@ -281,8 +305,7 @@ make sure that you are using an up-to-date version of NumPy. You can update NumP
 pip3 install numpy --upgrade
 ```
 
-
-# Contributors
+## Contributors
 
 * [Benjamin Rodenberg](https://github.com/BenjaminRodenberg)
 * [Ishaan Desai](https://github.com/IshaanDesai)

--- a/docs/MigrationGuide.md
+++ b/docs/MigrationGuide.md
@@ -1,11 +1,10 @@
-Migration Guide for Python language bindings for preCICE version 2.0
-------------------------------------
+# Migration Guide for Python language bindings for preCICE version 2.0
 
-# Steps to move from old Python API to the new API
+## Steps to move from old Python API to the new API
 
 ### 1. Python language bindings moved to a new repository in the preCICE Project
 
-Previously, the Python language bindings were part of the repository [`precice/precice`](https://github.com/precice/precice). 
+Previously, the Python language bindings were part of the repository [`precice/precice`](https://github.com/precice/precice).
 The bindings have now been moved to the independent repository [`precice/python-bindings`](https://github.com/precice/python-bindings).
 
 The installation procedure is the same as before. Please refer to the [README](https://github.com/precice/python-bindings/blob/develop/README.md).
@@ -16,13 +15,15 @@ The initialization of the `Interface` object now initializes the solver and also
 file provided by the user.
 
 **Old:** Before preCICE Version 2 you had to call:
-```
+
+```python
 interface = precice.Interface(solverName, processRank, processSize)
 interface.configure(configFileName)
 ```
 
 **New:** The two commands have now been combined into a single one:
-```
+
+```python
 interface = precice.Interface(solverName, configFileName, processRank, processSize)
 ```
 
@@ -33,14 +34,17 @@ Unlike the old bindings, API calls now do not need the array size to be passed a
 For example let us consider the call `write_block_vector_data`:
 
 **Old:** The previous call was:
-```
+
+```python
 interface.write_block_vector_data(writeDataID, writeDataSize, vertexIDs, writeDataArray)
 ```
 
 **New:** The new function call is:
-```
+
+```python
 interface.write_block_vector_data(writeDataID, vertexIDs, writeDataArray)
 ```
+
 The same change is applied for all other calls which work with arrays of data.
 
 ### 4. API functions use a return value, if appropriate
@@ -50,16 +54,20 @@ In older versions of the python bindings arrays were modified by the API in a ca
 For example let us consider the interface function `set_mesh_vertices`. `set_mesh_vertices` is used to register vertices for a mesh and it returns an array of `vertexIDs`.
 
 **Old:** The old signature of this function was:
-```
+
+```python
 vertexIDs = np.zeros(numberofVertices)
 interface.set_mesh_vertices(meshID, numberofVertices, grid, vertexIDs)
 ```
+
 Note that `vertexIDs` is passed as an argument to the function.
 
 **New:** This has now been changed to:
-```
+
+```python
 vertexIDs = interface.set_mesh_vertices(meshID, grid)
 ```
+
 Here, `vertexIDs` is directly returned by `set_mesh_vertices`.
 
 The same change has been applied to the functions `read_block_scalar_data` and `read_block_vector_data`.

--- a/docs/ReleaseGuide.md
+++ b/docs/ReleaseGuide.md
@@ -1,4 +1,5 @@
-## Guide to release new version of python-bindings
+# Guide to release new version of python-bindings
+
 The developer who is releasing a new version of the python-bindings is expected to follow this work flow:
 
 The release of the `python-bindings` repository is made directly from a release branch called `python-bindings-v2.1.1.1`. This branch is mainly needed to help other developers with testing.
@@ -12,7 +13,7 @@ The release of the `python-bindings` repository is made directly from a release 
     * `CHANGELOG.md` on `python-bindings-v2.1.1.1`.
     * There is no need to bump the version anywhere else, since we use the [python-versioneer](https://github.com/python-versioneer/python-versioneer/) for maintaining the version everywhere else.
 
-4. [Draft a New Release](https://github.com/precice/python-bindings/releases/new) in the `Releases` section of the repository page in a web browser. The release tag needs to be the exact version number (i.e.`v2.1.1.1` or `v2.1.1.1rc1`, compare to [existing tags](https://github.com/precice/python-bindings/tags)). Use `@target:master`. Release title is also the version number (i.e. `v2.1.1.1` or `v2.1.1.1rc1`, compare to [existing releases](https://github.com/precice/python-bindings/tags)). 
+4. [Draft a New Release](https://github.com/precice/python-bindings/releases/new) in the `Releases` section of the repository page in a web browser. The release tag needs to be the exact version number (i.e.`v2.1.1.1` or `v2.1.1.1rc1`, compare to [existing tags](https://github.com/precice/python-bindings/tags)). Use `@target:master`. Release title is also the version number (i.e. `v2.1.1.1` or `v2.1.1.1rc1`, compare to [existing releases](https://github.com/precice/python-bindings/tags)).
 
     * *Note:* We use the [python-versioneer](https://github.com/python-versioneer/python-versioneer/) for maintaining the version. Therefore the tag directly defines the version in all relevant places.
     * *Note:* If it is a pre-release then the option *This is a pre-release* needs to be selected at the bottom of the page. Use `@target:python-bindings-v2.1.1.1` for a pre-release, since we will never merge a pre-release into master.
@@ -28,23 +29,23 @@ The release of the `python-bindings` repository is made directly from a release 
 
 7. Add an empty commit on master via `git checkout master`, then `git commit --allow-empty -m "post-tag bump"`. Check that everything is in order via `git log`. Important: The `tag` and `origin/master` should not point to the same commit. For example:
 
-```
-commit 44b715dde4e3194fa69e61045089ca4ec6925fe3 (HEAD -> master, origin/master)
-Author: Benjamin Rodenberg <benjamin.rodenberg@in.tum.de>
-Date:   Wed Oct 20 10:52:41 2021 +0200
+   ```bash
+   commit 44b715dde4e3194fa69e61045089ca4ec6925fe3 (HEAD -> master, origin/master)
+   Author: Benjamin Rodenberg <benjamin.rodenberg@in.tum.de>
+   Date:   Wed Oct 20 10:52:41 2021 +0200
 
-    post-tag bump
+       post-tag bump
 
-commit d2645cc51f84ad5eda43b9c673400aada8e1505a (tag: v2.3.0.1)
-Merge: 2039557 aca2354
-Author: Benjamin Rodenberg <benjamin.rodenberg@in.tum.de>
-Date:   Tue Oct 19 12:57:24 2021 +0200
+   commit d2645cc51f84ad5eda43b9c673400aada8e1505a (tag: v2.3.0.1)
+   Merge: 2039557 aca2354
+   Author: Benjamin Rodenberg <benjamin.rodenberg@in.tum.de>
+   Date:   Tue Oct 19 12:57:24 2021 +0200
 
-    Merge pull request #132 from precice/python-bindings-v2.3.0.1
-    
-    Release v2.3.0.1
-```
+       Merge pull request #132 from precice/python-bindings-v2.3.0.1
 
-For more details refer to https://github.com/precice/python-bindings/issues/109 and https://github.com/python-versioneer/python-versioneer/issues/217.
+       Release v2.3.0.1
+   ```
+
+   For more details refer to https://github.com/precice/python-bindings/issues/109 and https://github.com/python-versioneer/python-versioneer/issues/217.
 
 8. Update Spack package (refer to `python-bindings/spack/README.md`).

--- a/examples/solverdummy/README.md
+++ b/examples/solverdummy/README.md
@@ -1,15 +1,18 @@
-# Install Dependencies
+# Solverdummies
+
+## Install Dependencies
 
 * [preCICE](https://github.com/precice/precice)
 * [python bindings](https://github.com/precice/python-bindings)
 * Run in this directory `pip3 install --user -r requirements.txt`
 
-# Run
+## Run
 
 You can test the dummy solver by coupling two instances with each other. Open two terminals and run
- * `python3 solverdummy.py precice-config.xml SolverOne`
- * `python3 solverdummy.py precice-config.xml SolverTwo`
 
-# Next Steps
+* `python3 solverdummy.py precice-config.xml SolverOne`
+* `python3 solverdummy.py precice-config.xml SolverTwo`
+
+## Next Steps
 
 If you want to couple any other solver against this dummy solver be sure to adjust the preCICE configuration (participant names, mesh names, data names etc.) to the needs of your solver, compare our [step-by-step guide for new adapters](https://github.com/precice/precice/wiki/Adapter-Example).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
 # PEP 518 - minimum build system requirements
-requires = ["setuptools", "wheel", "Cython>=0.29", "packaging", "pip>=19.0.0", "numpy", "mpi4py", "pkgconfig"]
+requires = ["setuptools>=61", "wheel", "Cython>=0.29", "packaging", "pip>=19.0.0", "numpy", "mpi4py", "pkgconfig"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
 # PEP 518 - minimum build system requirements
-requires = ["setuptools>=61", "wheel", "Cython>=0.29", "packaging", "pip>=19.0.0", "numpy", "mpi4py", "pkgconfig"]
+requires = ["setuptools>=61,<72", "wheel", "Cython>=0.29", "packaging", "pip>=19.0.0", "numpy<2", "mpi4py", "pkgconfig"]

--- a/setup.py
+++ b/setup.py
@@ -5,17 +5,6 @@ import versioneer
 
 uses_pip = "pip" in __file__
 
-# check whether pip is used for installation. If pip is not used, dependencies defined in pyproject.toml might be
-# missing.
-if not uses_pip:
-    warnings.warn(
-        "It looks like you are not using pip for installation. Installing the package via 'pip3 install "
-        "--user .' is recommended. You can still use 'python3 setup.py install --user', if you want and if "
-        "the bindings work correctly, you do not have to worry. However, if you face problems during "
-        "installation or running pyprecice, this means that you have to make sure that all dependencies are "
-        "installed correctly and repeat the installation of pyprecice. Refer to pyproject.toml for a list "
-        "of dependencies.")
-
 if uses_pip:
     # If installed with pip we need to check its version
     try:
@@ -45,7 +34,6 @@ if uses_pip:
                 " flag.".format(pip.__version__))
 
 from setuptools import setup
-from setuptools import Command
 from setuptools.command.test import test
 from setuptools.command.install import install
 from Cython.Distutils.extension import Extension

--- a/setup.py
+++ b/setup.py
@@ -148,7 +148,7 @@ setup(
     author_email='info@precice.org',
     license='LGPL-3.0',
     python_requires='>=3',
-    install_requires=['numpy', 'mpi4py'],
+    install_requires=['numpy', 'mpi4py', 'Cython'],
     # mpi4py is only needed, if preCICE was compiled with MPI
     # see https://github.com/precice/python-bindings/issues/8
     packages=['precice'],

--- a/setup.py
+++ b/setup.py
@@ -136,7 +136,7 @@ setup(
     author_email='info@precice.org',
     license='LGPL-3.0',
     python_requires='>=3',
-    install_requires=['numpy', 'mpi4py', 'Cython'],
+    install_requires=['numpy<2', 'mpi4py', 'Cython'],
     # mpi4py is only needed, if preCICE was compiled with MPI
     # see https://github.com/precice/python-bindings/issues/8
     packages=['precice'],

--- a/spack/README.md
+++ b/spack/README.md
@@ -2,11 +2,11 @@
 
 The Spack package `py-pyprecice` provides the python bindings via Spack and was submitted via [pull request 19558](https://github.com/spack/spack/pull/19558) in the Spack repository. This folder contains the Spack package script that can be used for testing whether the Spack installation works.
 
-## Docker image `precice/ci-spack-pyprecice-deps-2204`
+## Docker image `precice/ci-spack-pyprecice-deps-2404`
 
-The workflow `build-spack-pyprecice-deps` in `.github/workflows/build-env.yml` creates the image `precice/ci-spack-pyprecice-deps-2204`. This image contains all dependencies of `py-pyprecice@develop`.
+The workflow `build-spack-pyprecice-deps` in `.github/workflows/build-env.yml` creates the image `precice/ci-spack-pyprecice-deps-2404`. This image contains all dependencies of `py-pyprecice@develop`.
 
-The workflow `build_spack` in `.github/workflows/build-spack.yml` uses the image `precice/ci-spack-pyprecice-deps-2204` to reduce build time. The workflow uses the `package.py` from this repository to build the latest version of the bindings and run a small test on this version.
+The workflow `build_spack` in `.github/workflows/build-spack.yml` uses the image `precice/ci-spack-pyprecice-deps-2404` to reduce build time. The workflow uses the `package.py` from this repository to build the latest version of the bindings and run a small test on this version.
 
 ## When a new Spack release is necessary
 

--- a/spack/ci-spack-pyprecice-deps-2404.dockerfile
+++ b/spack/ci-spack-pyprecice-deps-2404.dockerfile
@@ -6,6 +6,6 @@ FROM spack/ubuntu-noble:latest
 ADD ./spack/repo /py-pyprecice-repo
 RUN spack --color=always env create --without-view ci && \
     spack --color=always -e ci repo add /py-pyprecice-repo && \
-    spack --color=always -e ci add pyprecice.test.py-pyprecice@develop target=x86_64 && \
+    spack --color=always -e ci add pyprecice.test.py-pyprecice@2.5.1.0 target=x86_64 && \
     spack --color=always -e ci install --fail-fast --only=dependencies && \
     spack --color=always clean -a

--- a/spack/ci-spack-pyprecice-deps-2404.dockerfile
+++ b/spack/ci-spack-pyprecice-deps-2404.dockerfile
@@ -1,5 +1,5 @@
 # Build stage with Spack pre-installed and ready to be used
-FROM spack/ubuntu-jammy:latest
+FROM spack/ubuntu-noble:latest
 
 # Mount the current sources into the build container
 # and build the default environment

--- a/spack/repo/packages/py-pyprecice/package.py
+++ b/spack/repo/packages/py-pyprecice/package.py
@@ -50,8 +50,8 @@ class PyPyprecice(PythonPackage):
         depends_on("precice@" + ver, when="@" + ver)
 
     depends_on("python@3:", type=("build", "link", "run"))
-    depends_on("py-setuptools@61:", type="build")
-    depends_on("py-numpy", type=("build", "link", "run"))
+    depends_on("py-setuptools@61:71", type="build")
+    depends_on("py-numpy@:1", type=("build", "link", "run"))
     depends_on("py-mpi4py", type=("build", "run"))
     depends_on("py-cython@0.29:", type="build")
     depends_on("py-packaging", type="build")

--- a/spack/repo/packages/py-pyprecice/package.py
+++ b/spack/repo/packages/py-pyprecice/package.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
@@ -14,12 +14,12 @@ class PyPyprecice(PythonPackage):
 
     homepage = "https://precice.org"
     git = "https://github.com/precice/python-bindings.git"
-    url = "https://github.com/precice/python-bindings/archive/v2.4.0.0.tar.gz"
-    maintainers = ["ajaust", "BenjaminRodenberg", "IshaanDesai"]
+    url = "https://github.com/precice/python-bindings/archive/v2.5.0.1.tar.gz"
+    maintainers("ajaust", "BenjaminRodenberg", "IshaanDesai")
 
     # Always prefer final version of release candidate
     version("develop", branch="develop")
-    version("2.5.0.1", sha256="e2602f828d4f907ea93e34f7d4adb8db086044a75a446592a4099423d56ed62c")
+    version("2.5.0.1", sha256="d7c666e6ebff9e007c3703d8e3c3fcdf0f45289e36c2c17223b3aedc3259ab6c")
     version("2.5.0.0", sha256="9f55a22594bb602cde8a5987217728569f16d9576ea53ed00497e9046a2e1794")
     version("2.4.0.0", sha256="e80d16417b8ce1fdac80c988cb18ae1e16f785c5eb1035934d8b37ac18945242")
     version("2.3.0.1", sha256="ed4e48729b662680beaa4ee2a9aff724a79e760534c6c58181be739988da2789")
@@ -50,7 +50,7 @@ class PyPyprecice(PythonPackage):
         depends_on("precice@" + ver, when="@" + ver)
 
     depends_on("python@3:", type=("build", "link", "run"))
-    depends_on("py-setuptools", type="build")
+    depends_on("py-setuptools@61:", type="build")
     depends_on("py-numpy", type=("build", "link", "run"))
     depends_on("py-mpi4py", type=("build", "run"))
     depends_on("py-cython@0.29:", type="build")

--- a/spack/repo/packages/py-pyprecice/package.py
+++ b/spack/repo/packages/py-pyprecice/package.py
@@ -34,8 +34,12 @@ class PyPyprecice(PythonPackage):
     version("2.0.0.2", sha256="5f055d809d65ec2e81f4d001812a250f50418de59990b47d6bcb12b88da5f5d7")
     version("2.0.0.1", sha256="96eafdf421ec61ad6fcf0ab1d3cf210831a815272984c470b2aea57d4d0c9e0e")
 
+    # release candidate
+    version("2.5.1.0", branch="python-bindings-v2.5.1.0")
+
     for ver in [
         "develop",
+        "2.5.1",
         "2.5.0",
         "2.4.0",
         "2.3.0",

--- a/tools/releasing/packaging/docker/Dockerfile
+++ b/tools/releasing/packaging/docker/Dockerfile
@@ -1,6 +1,6 @@
 # Dockerfile to build a ubuntu image containing the installed Debian package of a release 
-ARG branch=develop
-ARG from=precice/precice:latest
+ARG PRECICE_TAG=develop
+ARG from=precice/precice:${PRECICE_TAG}
 FROM $from
 
 USER root
@@ -41,8 +41,7 @@ SHELL ["/bin/bash", "-c"]
 RUN python3 -m pip install --user --upgrade pip
 
 # Rebuild image if force_rebuild after that command
-ARG CACHEBUST
-ARG branch=develop
+ARG PYTHON_BINDINGS_REF=develop
 
 # Builds the precice python bindings for python3
-RUN pip3 install --user git+https://github.com/precice/python-bindings.git@$branch
+RUN pip3 install --user git+https://github.com/precice/python-bindings.git@${PYTHON_BINDINGS_REF}


### PR DESCRIPTION
Backports some trivial changes to v2.5.0.
Compatibility release for preCICE [v2.5.1](https://github.com/precice/precice/releases/tag/v2.5.1).
Closes #203