### PR TITLE
Restrict to numpy < 2 and setuptools < 72 for better compatibiltiy with CI pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## latest
 
 * Restrict to numpy < 2 for better compatibility with CI pipeline. https://github.com/precice/python-bindings/pull/213
+* Require setuptools < 72 since support for the test command was removed in Setuptools 72. https://github.com/precice/python-bindings/pull/213
 * Require setuptools >= 61 to guarantee that pyproject.toml is used https://github.com/precice/python-bindings/pull/207
 * Fix CI pipeline for spack https://github.com/precice/python-bindings/pull/206
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## latest
 
+* Restrict to numpy < 2 for better compatibility with CI pipeline. https://github.com/precice/python-bindings/pull/213
 * Require setuptools >= 61 to guarantee that pyproject.toml is used https://github.com/precice/python-bindings/pull/207
 * Fix CI pipeline for spack https://github.com/precice/python-bindings/pull/206
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
 # PEP 518 - minimum build system requirements
-requires = ["setuptools>=61", "wheel", "Cython>=0.29", "packaging", "pip>=19.0.0", "numpy", "mpi4py", "pkgconfig"]
+requires = ["setuptools>=61", "wheel", "Cython>=0.29", "packaging", "pip>=19.0.0", "numpy<2", "mpi4py", "pkgconfig"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
 # PEP 518 - minimum build system requirements
-requires = ["setuptools>=61,setuptools<72", "wheel", "Cython>=0.29", "packaging", "pip>=19.0.0", "numpy<2", "mpi4py", "pkgconfig"]
+requires = ["setuptools>=61,<72", "wheel", "Cython>=0.29", "packaging", "pip>=19.0.0", "numpy<2", "mpi4py", "pkgconfig"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
 # PEP 518 - minimum build system requirements
-requires = ["setuptools>=61", "wheel", "Cython>=0.29", "packaging", "pip>=19.0.0", "numpy<2", "mpi4py", "pkgconfig"]
+requires = ["setuptools>=61,setuptools<72", "wheel", "Cython>=0.29", "packaging", "pip>=19.0.0", "numpy<2", "mpi4py", "pkgconfig"]

--- a/setup.py
+++ b/setup.py
@@ -137,7 +137,7 @@ setup(
     author_email='info@precice.org',
     license='LGPL-3.0',
     python_requires='>=3',
-    install_requires=['numpy', 'mpi4py', 'Cython'],
+    install_requires=['numpy<2', 'mpi4py', 'Cython'],
     # mpi4py is only needed, if preCICE was compiled with MPI
     # see https://github.com/precice/python-bindings/issues/8
     packages=['precice'],

--- a/spack/repo/packages/py-pyprecice/package.py
+++ b/spack/repo/packages/py-pyprecice/package.py
@@ -58,8 +58,8 @@ class PyPyprecice(PythonPackage):
         depends_on("precice@" + ver, when="@" + ver)
 
     depends_on("python@3:", type=("build", "link", "run"))
-    depends_on("py-setuptools@61:", type="build")
-    depends_on("py-numpy", type=("build", "link", "run"))
+    depends_on("py-setuptools@61:71", type="build")
+    depends_on("py-numpy@:1", type=("build", "link", "run"))
     depends_on("py-mpi4py", type=("build", "run"))
     depends_on("py-cython@0.29:", type="build")
     depends_on("py-packaging", type="build")


### PR DESCRIPTION
I would suggest to restrict the numpy version to `numpy<2` since the newest numpy is not well supported by our CI pipeline (see #212).