### PR TITLE
Allow numpy 2 for pyprecice>=3.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
 # PEP 518 - minimum build system requirements
-requires = ["setuptools>=61,<72", "wheel", "Cython>=0.29", "packaging", "pip>=19.0.0", "numpy<2", "mpi4py", "pkgconfig"]
+requires = ["setuptools>=61,<72", "wheel", "Cython>=0.29", "packaging", "pip>=19.0.0", "numpy", "mpi4py", "pkgconfig"]

--- a/setup.py
+++ b/setup.py
@@ -137,7 +137,7 @@ setup(
     author_email='info@precice.org',
     license='LGPL-3.0',
     python_requires='>=3',
-    install_requires=['numpy<2', 'mpi4py', 'Cython'],
+    install_requires=['numpy', 'mpi4py', 'Cython'],
     # mpi4py is only needed, if preCICE was compiled with MPI
     # see https://github.com/precice/python-bindings/issues/8
     packages=['precice'],

--- a/spack/repo/packages/py-pyprecice/package.py
+++ b/spack/repo/packages/py-pyprecice/package.py
@@ -59,7 +59,6 @@ class PyPyprecice(PythonPackage):
 
     depends_on("python@3:", type=("build", "link", "run"))
     depends_on("py-setuptools@61:71", type="build")
-    depends_on("py-numpy@2:", type=("build", "link", "run"), when="@develop")  # explicitly specity develop
     depends_on("py-numpy", type=("build", "link", "run"), when="@3.1.1:")
     depends_on("py-numpy@:1", type=("build", "link", "run"), when="@:3.1.1")
     depends_on("py-mpi4py", type=("build", "run"))

--- a/spack/repo/packages/py-pyprecice/package.py
+++ b/spack/repo/packages/py-pyprecice/package.py
@@ -59,7 +59,7 @@ class PyPyprecice(PythonPackage):
 
     depends_on("python@3:", type=("build", "link", "run"))
     depends_on("py-setuptools@61:71", type="build")
-    depends_on("py-numpy", type=("build", "link", "run"), when="@develop")  # explicitly specity develop
+    depends_on("py-numpy@2:", type=("build", "link", "run"), when="@develop")  # explicitly specity develop
     depends_on("py-numpy", type=("build", "link", "run"), when="@3.1.1:")
     depends_on("py-numpy@:1", type=("build", "link", "run"), when="@:3.1.1")
     depends_on("py-mpi4py", type=("build", "run"))

--- a/spack/repo/packages/py-pyprecice/package.py
+++ b/spack/repo/packages/py-pyprecice/package.py
@@ -59,8 +59,9 @@ class PyPyprecice(PythonPackage):
 
     depends_on("python@3:", type=("build", "link", "run"))
     depends_on("py-setuptools@61:71", type="build")
-    depends_on("py-numpy@:1", type=("build", "link", "run"), when="@:3.1.1")
+    depends_on("py-numpy:", type=("build", "link", "run"), when="@develop")  # explicitly specity develop
     depends_on("py-numpy", type=("build", "link", "run"), when="@3.1.1:")
+    depends_on("py-numpy@:1", type=("build", "link", "run"), when="@:3.1.1")
     depends_on("py-mpi4py", type=("build", "run"))
     depends_on("py-cython@0.29:", type="build")
     depends_on("py-packaging", type="build")

--- a/spack/repo/packages/py-pyprecice/package.py
+++ b/spack/repo/packages/py-pyprecice/package.py
@@ -59,7 +59,7 @@ class PyPyprecice(PythonPackage):
 
     depends_on("python@3:", type=("build", "link", "run"))
     depends_on("py-setuptools@61:71", type="build")
-    depends_on("py-numpy:", type=("build", "link", "run"), when="@develop")  # explicitly specity develop
+    depends_on("py-numpy", type=("build", "link", "run"), when="@develop")  # explicitly specity develop
     depends_on("py-numpy", type=("build", "link", "run"), when="@3.1.1:")
     depends_on("py-numpy@:1", type=("build", "link", "run"), when="@:3.1.1")
     depends_on("py-mpi4py", type=("build", "run"))

--- a/spack/repo/packages/py-pyprecice/package.py
+++ b/spack/repo/packages/py-pyprecice/package.py
@@ -59,7 +59,8 @@ class PyPyprecice(PythonPackage):
 
     depends_on("python@3:", type=("build", "link", "run"))
     depends_on("py-setuptools@61:71", type="build")
-    depends_on("py-numpy@:1", type=("build", "link", "run"))
+    depends_on("py-numpy@:1", type=("build", "link", "run"), when="@:3.1.1")
+    depends_on("py-numpy", type=("build", "link", "run"), when="@3.1.1:")
     depends_on("py-mpi4py", type=("build", "run"))
     depends_on("py-cython@0.29:", type="build")
     depends_on("py-packaging", type="build")


### PR DESCRIPTION
Closes https://github.com/precice/python-bindings/issues/219

To some degree I would also consider this as a bugfix since Numpy support was implemented for `3.1.1` in #204 and broken in `3.1.2` via #213.