### PR TITLE
Improve install error messages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,15 @@ def get_extensions(is_test):
     bindings_sources = [os.path.join(PYTHON_BINDINGS_PATH, "cyprecice",
                                      "cyprecice" + ".pyx")]
 
+    if not pkgconfig.exists('libprecice'):
+        raise Exception("\n".join([
+            "pkg-config was unable to find libprecice.",
+            "Please make sure that preCICE was installed correctly and pkg-config is able to find it.",
+            "You may need to set PKG_CONFIG_PATH to include the location of the libprecice.pc file.",
+            "Use \"pkg-config --modversion libprecice\" for debugging."]))
+
+    print("Found preCICE version " + pkgconfig.modversion('libprecice'))
+
     compile_args += pkgconfig.cflags('libprecice').split()
 
     if not is_test:

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,8 @@ def get_extensions(is_test):
             language="c++",
             include_dirs=include_dirs,
             extra_compile_args=compile_args,
-            extra_link_args=link_args
+            extra_link_args=link_args,
+            define_macros=[("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")]
         )
     ]
 


### PR DESCRIPTION
This PR adds a more helpful error message when the python bindings cannot find preCICE using pkg-config.
It also silences the NumPy warning to prevent it from distracting from the actual problem.
