### PR TITLE
Add API for runtime remeshing

### DIFF
--- a/changelog-entries/224.md
+++ b/changelog-entries/224.md
@@ -1,0 +1,1 @@
+- Added API function `reset_mesh()`

--- a/cyprecice/Participant.pxd
+++ b/cyprecice/Participant.pxd
@@ -65,6 +65,10 @@ cdef extern from "precice/Participant.hpp" namespace "precice":
 
         void setMeshTetrahedra (const string& meshName, vector[int] vertices)
 
+        # remeshing
+
+        void resetMesh (const string& meshName)
+
         # data access
 
         void writeData (const string& meshName, const string& dataName, vector[int] vertices, vector[double] values)

--- a/cyprecice/cyprecice.pyx
+++ b/cyprecice/cyprecice.pyx
@@ -710,6 +710,42 @@ cdef class Participant:
 
         self.thisptr.setMeshTetrahedra (convert(mesh_name), cpp_vertices)
 
+    # remeshing
+
+
+    def reset_mesh (self, mesh_name):
+        """
+        Resets a mesh and allows setting it using set_mesh functions again.
+
+        Parameters
+        ----------
+        mesh_name : str
+            Name of the mesh to reset.
+
+        Notes
+        -----
+        This function is still experimental.
+        Please refer to the documentation on how to enable and use it.
+
+        Previous calls:
+            advance() been called
+
+        Examples
+        --------
+        Set mesh vertices for a 2D problem with 5 mesh vertices.
+
+        >>> positions = np.array([[1, 1], [2, 2], [3, 3], [4, 4], [5, 5]])
+        >>> mesh_name = "MeshOne"
+        >>> vertex_ids = participant.set_mesh_vertices(mesh_name, positions)
+        >>> # later in the coupling loop
+        >>> if remeshing_required():
+        >>>     participant.reset_mesh(mesh_name)
+        >>>     positions = np.array([[1, 1], [3, 3], [5, 5]])
+        >>>     vertex_ids = participant.set_mesh_vertices(mesh_name, positions)
+        """
+
+        self.thisptr.resetMesh (convert(mesh_name))
+
     # data access
 
     def write_data (self, mesh_name, data_name, vertex_ids, values):

--- a/cyprecice/cyprecice.pyx
+++ b/cyprecice/cyprecice.pyx
@@ -728,11 +728,11 @@ cdef class Participant:
         Please refer to the documentation on how to enable and use it.
 
         Previous calls:
-            advance() been called
+            advance() has been called
 
         Examples
         --------
-        Set mesh vertices for a 2D problem with 5 mesh vertices.
+        Reset a mesh with 5 vertices to have 3 vertices.
 
         >>> positions = np.array([[1, 1], [2, 2], [3, 3], [4, 4], [5, 5]])
         >>> mesh_name = "MeshOne"

--- a/test/Participant.cpp
+++ b/test/Participant.cpp
@@ -237,6 +237,11 @@ void Participant::setMeshTetrahedra
     precice::span<const precice::VertexID> vertices)
 {}
 
+void Participant::resetMesh
+(
+    precice::string_view meshName)
+{}
+
 void Participant:: writeData
 (
   precice::string_view meshName,

--- a/test/test_bindings_module.py
+++ b/test/test_bindings_module.py
@@ -43,6 +43,11 @@ class TestBindings(TestCase):
         fake_mesh_name = "FakeMesh"
         self.assertEqual(fake_bool, participant.requires_mesh_connectivity_for(fake_mesh_name))
 
+    def test_reset_mesh(self):
+        participant = precice.Participant("test", "dummy.xml", 0, 1)
+        fake_mesh_name = "FakeMesh"
+        participant.reset_mesh(fake_mesh_name)
+
     def test_set_mesh_vertices(self):
         participant = precice.Participant("test", "dummy.xml", 0, 1)
         fake_mesh_name = "FakeMesh"  # compare to test/SolverInterface.cpp, fake_mesh_name


### PR DESCRIPTION
This PR adds the API for runtime remeshing to the python bindings.

The feature is available in the develop version of preCICE https://github.com/precice/precice/pull/2070

As the limitations are still changing, I refer the user to the online documentation.