### PR TITLE
Add exception support

### DIFF
--- a/cyprecice/Participant.pxd
+++ b/cyprecice/Participant.pxd
@@ -11,8 +11,6 @@ cdef extern from "precice/Participant.hpp" namespace "precice":
 
         Participant (const string&, const string&, int, int, void*) except +
 
-        void configure (const string&)
-
         # steering methods
 
         void initialize ()

--- a/cyprecice/Participant.pxd
+++ b/cyprecice/Participant.pxd
@@ -13,17 +13,17 @@ cdef extern from "precice/Participant.hpp" namespace "precice":
 
         # steering methods
 
-        void initialize ()
+        void initialize () except +
 
-        void advance (double computedTimestepLength)
+        void advance (double computedTimestepLength) except +
 
         void finalize()
 
         # status queries
 
-        int getMeshDimensions(const string& meshName)
+        int getMeshDimensions(const string& meshName) except +
 
-        int getDataDimensions(const string& meshName, const string& dataName)
+        int getDataDimensions(const string& meshName, const string& dataName) except +
 
         bool isCouplingOngoing()
 
@@ -39,51 +39,51 @@ cdef extern from "precice/Participant.hpp" namespace "precice":
 
         # mesh access
 
-        bool requiresMeshConnectivityFor (const string& meshName)
+        bool requiresMeshConnectivityFor (const string& meshName) except +
 
-        int setMeshVertex (const string& meshName, vector[double] position)
+        int setMeshVertex (const string& meshName, vector[double] position) except +
 
-        int getMeshVertexSize (const string& meshName)
+        int getMeshVertexSize (const string& meshName) except +
 
-        void setMeshVertices (const string& meshName, vector[double] positions, vector[int]& ids)
+        void setMeshVertices (const string& meshName, vector[double] positions, vector[int]& ids) except +
 
-        void setMeshEdge (const string& meshName, int firstVertexID, int secondVertexID)
+        void setMeshEdge (const string& meshName, int firstVertexID, int secondVertexID) except +
 
-        void setMeshEdges (const string& meshName, vector[int] vertices)
+        void setMeshEdges (const string& meshName, vector[int] vertices) except +
 
-        void setMeshTriangle (const string& meshName, int firstVertexID, int secondVertexID, int thirdVertexID)
+        void setMeshTriangle (const string& meshName, int firstVertexID, int secondVertexID, int thirdVertexID) except +
 
-        void setMeshTriangles (const string& meshName, vector[int] vertices)
+        void setMeshTriangles (const string& meshName, vector[int] vertices) except +
 
-        void setMeshQuad (const string& meshName, int firstVertexID, int secondVertexID, int thirdVertexID, int fourthVertexID)
+        void setMeshQuad (const string& meshName, int firstVertexID, int secondVertexID, int thirdVertexID, int fourthVertexID) except +
 
-        void setMeshQuads (const string& meshName, vector[int] vertices)
+        void setMeshQuads (const string& meshName, vector[int] vertices) except +
 
-        void setMeshTetrahedron (const string& meshName, int firstVertexID, int secondVertexID, int thirdVertexID, int fourthVertexID)
+        void setMeshTetrahedron (const string& meshName, int firstVertexID, int secondVertexID, int thirdVertexID, int fourthVertexID) except +
 
-        void setMeshTetrahedra (const string& meshName, vector[int] vertices)
+        void setMeshTetrahedra (const string& meshName, vector[int] vertices) except +
 
         # remeshing
 
-        void resetMesh (const string& meshName)
+        void resetMesh (const string& meshName) except +
 
         # data access
 
-        void writeData (const string& meshName, const string& dataName, vector[int] vertices, vector[double] values)
+        void writeData (const string& meshName, const string& dataName, vector[int] vertices, vector[double] values) except +
 
-        void readData (const string& meshName, const string& dataName, vector[int] vertices, const double relativeReadTime, vector[double]& values)
+        void readData (const string& meshName, const string& dataName, vector[int] vertices, const double relativeReadTime, vector[double]& values) except +
 
         # direct access
 
-        void setMeshAccessRegion (const string& meshName, vector[double] boundingBox)
+        void setMeshAccessRegion (const string& meshName, vector[double] boundingBox) except +
 
-        void getMeshVertexIDsAndCoordinates (const string& meshName, vector[int]& ids, vector[double]& coordinates)
+        void getMeshVertexIDsAndCoordinates (const string& meshName, vector[int]& ids, vector[double]& coordinates) except +
 
         # Gradient related API
 
-        bool requiresGradientDataFor(const string& meshName, const string& dataName)
+        bool requiresGradientDataFor(const string& meshName, const string& dataName) except +
 
-        void writeGradientData(const string& meshName, const string& dataName, vector[int] vertices, vector[double] gradientValues)
+        void writeGradientData(const string& meshName, const string& dataName, vector[int] vertices, vector[double] gradientValues) except +
 
 
 cdef extern from "precice/Tooling.hpp" namespace "precice":

--- a/cyprecice/Participant.pxd
+++ b/cyprecice/Participant.pxd
@@ -21,15 +21,15 @@ cdef extern from "precice/Participant.hpp" namespace "precice":
 
         # status queries
 
-        int getMeshDimensions(const string& meshName) const
+        int getMeshDimensions(const string& meshName)
 
-        int getDataDimensions(const string& meshName, const string& dataName) const
+        int getDataDimensions(const string& meshName, const string& dataName)
 
-        bool isCouplingOngoing() const
+        bool isCouplingOngoing()
 
-        bool isTimeWindowComplete() const
+        bool isTimeWindowComplete()
 
-        double getMaxTimeStepSize() const
+        double getMaxTimeStepSize()
 
         bool requiresInitialData()
 
@@ -39,11 +39,11 @@ cdef extern from "precice/Participant.hpp" namespace "precice":
 
         # mesh access
 
-        bool requiresMeshConnectivityFor (const string& meshName) const
+        bool requiresMeshConnectivityFor (const string& meshName)
 
         int setMeshVertex (const string& meshName, vector[double] position)
 
-        int getMeshVertexSize (const string& meshName) const
+        int getMeshVertexSize (const string& meshName)
 
         void setMeshVertices (const string& meshName, vector[double] positions, vector[int]& ids)
 
@@ -71,17 +71,17 @@ cdef extern from "precice/Participant.hpp" namespace "precice":
 
         void writeData (const string& meshName, const string& dataName, vector[int] vertices, vector[double] values)
 
-        void readData (const string& meshName, const string& dataName, vector[int] vertices, const double relativeReadTime, vector[double]& values) const
+        void readData (const string& meshName, const string& dataName, vector[int] vertices, const double relativeReadTime, vector[double]& values)
 
         # direct access
 
-        void setMeshAccessRegion (const string& meshName, vector[double] boundingBox) const
+        void setMeshAccessRegion (const string& meshName, vector[double] boundingBox)
 
-        void getMeshVertexIDsAndCoordinates (const string& meshName, vector[int]& ids, vector[double]& coordinates) const
+        void getMeshVertexIDsAndCoordinates (const string& meshName, vector[int]& ids, vector[double]& coordinates)
 
         # Gradient related API
 
-        bool requiresGradientDataFor(const string& meshName, const string& dataName) const
+        bool requiresGradientDataFor(const string& meshName, const string& dataName)
 
         void writeGradientData(const string& meshName, const string& dataName, vector[int] vertices, vector[double] gradientValues)
 


### PR DESCRIPTION
This PR adds exception support for the entire API.

Note that both `const` and `except` are incompatible, hence I had to remove the `const` member specifiers from the API.
This shouldn't be a problem as `const` is purely decorative as there is no `const` usage in python.

This implementation translates all exceptions into `RuntimeError`s on the python side. We could provide a custom `Error` as part of the `precice` module to make this cleaner.

Closes #173 