### PR TITLE
Add experimental profiling API

### DIFF
--- a/changelog-entries/226.md
+++ b/changelog-entries/226.md
@@ -1,0 +1,1 @@
+- Added profiling API which was introduced in preCICE in https://github.com/precice/precice/pull/1657

--- a/cyprecice/Participant.pxd
+++ b/cyprecice/Participant.pxd
@@ -87,6 +87,11 @@ cdef extern from "precice/Participant.hpp" namespace "precice":
 
         void writeGradientData(const string& meshName, const string& dataName, vector[int] vertices, vector[double] gradientValues)
 
+        # Experimental profiling API
+
+        void startProfilingSection(const string& eventName)
+
+        void stopLastProfilingSection()
 
 cdef extern from "precice/Tooling.hpp" namespace "precice":
     string getVersionInformation()

--- a/cyprecice/cyprecice.pyx
+++ b/cyprecice/cyprecice.pyx
@@ -1087,13 +1087,24 @@ cdef class Participant:
         Parameters
         ----------
         event_name : str
-            Name of the event to profile.    
+            Name of the event to profile.
+
+        Examples
+        --------
+        Start a profiling section with the event name "EventOne":
+        >>> event_name = "EventOne"
+        >>> participant.start_profiling_section(event_name)    
         """
         self.thisptr.startProfilingSection(convert(event_name))
 
     def stop_last_profiling_section(self):
         """
         Stops the last profiling section.
+
+        Examples
+        --------
+        Stop the last profiling section:
+        >>> participant.stop_last_profiling_section()
         """
         self.thisptr.stopLastProfilingSection()
 

--- a/cyprecice/cyprecice.pyx
+++ b/cyprecice/cyprecice.pyx
@@ -1080,6 +1080,23 @@ cdef class Participant:
 
         return np_ids, np_coordinates.reshape((size, dimensions))
 
+    def start_profiling_section(self, event_name):
+        """
+        Starts a profiling section with the given event name.
+        
+        Parameters
+        ----------
+        event_name : str
+            Name of the event to profile.    
+        """
+        self.thisptr.startProfilingSection(convert(event_name))
+
+    def stop_last_profiling_section(self):
+        """
+        Stops the last profiling section.
+        """
+        self.thisptr.stopLastProfilingSection()
+
 def get_version_information ():
     """
     Returns

--- a/test/Participant.cpp
+++ b/test/Participant.cpp
@@ -320,6 +320,15 @@ void Participant::writeGradientData(
   }
 }
 
+void Participant::startProfilingSection(
+    precice::string_view sectionName)
+{
+}
+
+void Participant::stopLastProfilingSection()
+{
+}
+
 std::string getVersionInformation()
 {
   return fake_version;


### PR DESCRIPTION
The profiling API from https://github.com/precice/precice/pull/1657 is added to the bindings. This PR should not be merged before https://github.com/precice/precice/pull/1657

The need for the profiling API arose from the need to accurately profile load balancing in https://github.com/precice/micro-manager/pull/141