### PR TITLE
Use `venv` for CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -22,13 +22,16 @@ jobs:
           apt-get -yy update
           apt-get install -y python3-pip pkg-config
           rm -rf /var/lib/apt/lists/*
-          pip3 install --upgrade --user pip
+      - name: Create venv
+        run: |
+          python3 -m venv .venv
+          . .venv/bin/activate
       - name: Install dependencies
         run: |
-          pip3 install --user toml
+          pip3 install toml
           python3 -c 'import toml; c = toml.load("pyproject.toml"); print("\n".join(c["build-system"]["requires"]))' | pip3 install -r /dev/stdin
       - name: Run setup install
-        run:  python3 setup.py install --user
+        run:  python3 setup.py install
       - name: Test install
         run: |
           export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
@@ -85,10 +88,13 @@ jobs:
           apt-get -yy update
           apt-get install -y python3-pip pkg-config
           rm -rf /var/lib/apt/lists/*
-          pip3 install --upgrade --user pip
+      - name: Create venv
+        run: |
+          python3 -m venv .venv
+          . .venv/bin/activate
       - name: Run pip install
-        run:  pip3 install --user .
-      - name: Run pip install
+        run:  pip3 install .
+      - name: Check import
         run: |
           export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
           python3 -c "import precice"
@@ -108,9 +114,12 @@ jobs:
           apt-get -yy update
           apt-get install -y python3-pip pkg-config
           rm -rf /var/lib/apt/lists/*
-          pip3 install --upgrade --user pip
+      - name: Create venv
+        run: |
+          python3 -m venv .venv
+          . .venv/bin/activate
       - name: Run pip install
-        run:  pip3 install --user .
+        run:  pip3 install .
       - name: Run solverdummy
         run: |
           export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -22,10 +22,15 @@ jobs:
           apt-get -yy update
           apt-get install -y python3-pip python3.12-venv pkg-config
           rm -rf /var/lib/apt/lists/*
-      - name: Create venv & install dependencies
+      - name: Create venv
+        run: python3 -m venv .venv
+      - name: Activate venv
+        # see https://stackoverflow.com/a/74669486
         run: |
-          python3 -m venv .venv
           . .venv/bin/activate
+          echo PATH=$PATH >> $GITHUB_ENV
+      - name: Install dependencies
+        run: |
           pip3 install toml
           python3 -c 'import toml; c = toml.load("pyproject.toml"); print("\n".join(c["build-system"]["requires"]))' | pip3 install -r /dev/stdin
       - name: Run setup install
@@ -89,7 +94,11 @@ jobs:
       - name: Create venv
         run: |
           python3 -m venv .venv
+      - name: Activate venv
+        # see https://stackoverflow.com/a/74669486
+        run: |
           . .venv/bin/activate
+          echo PATH=$PATH >> $GITHUB_ENV
       - name: Run pip install
         run:  pip3 install .
       - name: Check import
@@ -115,7 +124,11 @@ jobs:
       - name: Create venv
         run: |
           python3 -m venv .venv
+      - name: Activate venv
+        # see https://stackoverflow.com/a/74669486
+        run: |
           . .venv/bin/activate
+          echo PATH=$PATH >> $GITHUB_ENV
       - name: Run pip install
         run:  pip3 install .
       - name: Run solverdummy

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -22,12 +22,10 @@ jobs:
           apt-get -yy update
           apt-get install -y python3-pip python3.12-venv pkg-config
           rm -rf /var/lib/apt/lists/*
-      - name: Create venv
+      - name: Create venv & install dependencies
         run: |
           python3 -m venv .venv
           . .venv/bin/activate
-      - name: Install dependencies
-        run: |
           pip3 install toml
           python3 -c 'import toml; c = toml.load("pyproject.toml"); print("\n".join(c["build-system"]["requires"]))' | pip3 install -r /dev/stdin
       - name: Run setup install

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install pip3, pkgconfig and upgrade pip3
         run: |
           apt-get -yy update
-          apt-get install -y python3-pip pkg-config
+          apt-get install -y python3-pip python3.12-venv pkg-config
           rm -rf /var/lib/apt/lists/*
       - name: Create venv
         run: |
@@ -83,10 +83,10 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
-      - name: Install pip3, pkgconfig and upgrade pip3
+      - name: Install dependencies
         run: |
           apt-get -yy update
-          apt-get install -y python3-pip pkg-config
+          apt-get install -y python3-pip python3.12-venv pkg-config
           rm -rf /var/lib/apt/lists/*
       - name: Create venv
         run: |
@@ -109,10 +109,10 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
-      - name: Install pip3, pkgconfig and upgrade pip3
+      - name: Install dependencies
         run: |
           apt-get -yy update
-          apt-get install -y python3-pip pkg-config
+          apt-get install -y python3-pip python3.12-venv pkg-config
           rm -rf /var/lib/apt/lists/*
       - name: Create venv
         run: |

--- a/.github/workflows/run-solverdummy.yml
+++ b/.github/workflows/run-solverdummy.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install Dependencies
         run: |
           apt-get -qq update
-          apt-get -qq install software-properties-common python3-dev python3-pip git apt-utils pkg-config
+          apt-get -qq install software-properties-common python3-dev python3-pip python3.12-venv git apt-utils pkg-config
           rm -rf /var/lib/apt/lists/*
       - name: Create venv
         run: |

--- a/.github/workflows/run-solverdummy.yml
+++ b/.github/workflows/run-solverdummy.yml
@@ -21,7 +21,10 @@ jobs:
           apt-get -qq update
           apt-get -qq install software-properties-common python3-dev python3-pip git apt-utils pkg-config
           rm -rf /var/lib/apt/lists/*
-          pip3 install --upgrade --user pip
+      - name: Create venv
+        run: |
+          python3 -m venv .venv
+          . .venv/bin/activate
       - name: Install bindings
         run:  pip3 install --user .
       - name: Check whether preCICE was built with MPI  # reformat version information as a dict and check whether preCICE was compiled with MPI

--- a/.github/workflows/run-solverdummy.yml
+++ b/.github/workflows/run-solverdummy.yml
@@ -24,7 +24,11 @@ jobs:
       - name: Create venv
         run: |
           python3 -m venv .venv
+      - name: Activate venv
+        # see https://stackoverflow.com/a/74669486
+        run: |
           . .venv/bin/activate
+          echo PATH=$PATH >> $GITHUB_ENV
       - name: Install bindings
         run:  pip3 install --user .
       - name: Check whether preCICE was built with MPI  # reformat version information as a dict and check whether preCICE was compiled with MPI

--- a/.github/workflows/run-solverdummy.yml
+++ b/.github/workflows/run-solverdummy.yml
@@ -30,7 +30,7 @@ jobs:
           . .venv/bin/activate
           echo PATH=$PATH >> $GITHUB_ENV
       - name: Install bindings
-        run:  pip3 install --user .
+        run:  pip3 install .
       - name: Check whether preCICE was built with MPI  # reformat version information as a dict and check whether preCICE was compiled with MPI
         run: python3 -c "import precice; assert({item.split('=')[0]:item.split('=')[-1] for item in str(precice.get_version_information()).split(';')}['PRECICE_FEATURE_MPI_COMMUNICATION']=='Y')"
       - name: Run solverdummies


### PR DESCRIPTION
Required by recent pip versions (introduced with upgrade of Ubuntu base image for CI)