### PR TITLE
Move from adding individual changelog entries to directly editing the main file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## latest
 
+* Update `requirements.txt` of the solver dummy https://github.com/precice/python-bindings/pull/233
+* Add API functions for Just-in-time mapping https://github.com/precice/python-bindings/pull/231
 * Discontinued maintainment of Docker image `precice/python-bindings`. Python packages should be installed using virtual environments instead. Please refer to `README.md` for further information. https://github.com/precice/python-bindings/pull/228
+* Added profiling API functions https://github.com/precice/python-bindings/pull/226
+* Added API function `reset_mesh()` https://github.com/precice/python-bindings/pull/224
+* Removed testing of spack package https://github.com/precice/python-bindings/pull/221
+* Use the newer `precice/precice.hpp` header to access C++ API https://github.com/precice/python-bindings/pull/193
 
 ## 3.1.2
 

--- a/changelog-entries/193.md
+++ b/changelog-entries/193.md
@@ -1,1 +1,0 @@
-- Use the newer `precice/precice.hpp` header to access C++ API

--- a/changelog-entries/221.md
+++ b/changelog-entries/221.md
@@ -1,1 +1,0 @@
-* Removed testing of spack package

--- a/changelog-entries/224.md
+++ b/changelog-entries/224.md
@@ -1,1 +1,0 @@
-- Added API function `reset_mesh()`

--- a/changelog-entries/226.md
+++ b/changelog-entries/226.md
@@ -1,1 +1,0 @@
-- Added profiling API which was introduced in preCICE in https://github.com/precice/precice/pull/1657

--- a/changelog-entries/231.md
+++ b/changelog-entries/231.md
@@ -1,1 +1,0 @@
-- Add API functions for Just-in-time mapping https://github.com/precice/python-bindings/pull/231

--- a/changelog-entries/233.md
+++ b/changelog-entries/233.md
@@ -1,1 +1,0 @@
-- Update `requirements.txt` of the solver dummy https://github.com/precice/python-bindings/pull/233


### PR DESCRIPTION
This repository does not have too many contributions or parallel developments, so adding individual changelog entries is an overkill. This PR reverts to using one file for the changelog entries.