### PR TITLE
Add fallback for pkg-config in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-import pathlib
 from setuptools import setup
 from Cython.Distutils.extension import Extension
 from Cython.Build import cythonize
@@ -9,32 +8,35 @@ import os
 MOCKED_ENV = "PYPRECICE_MOCKED"
 
 
-def get_extensions():
+def find_precice():
     if not pkgconfig.exists("libprecice"):
-        raise Exception(
-            "\n".join(
-                [
-                    "pkg-config was unable to find libprecice.",
-                    "Please make sure that preCICE was installed correctly and pkg-config is able to find it.",
-                    "You may need to set PKG_CONFIG_PATH to include the location of the libprecice.pc file.",
-                    'Use "pkg-config --modversion libprecice" for debugging.',
-                ]
-            )
+        print(
+            "pkg-config was unable to find libprecice.\n"
+            "Please make sure that preCICE was installed correctly and pkg-config is able to find it.\n"
+            "You may need to set PKG_CONFIG_PATH to include the location of the libprecice.pc file.\n"
+            'Use "pkg-config --modversion libprecice" for debugging.'
         )
+        return [], ["-lprecice"]
 
-    print("Found preCICE version " + pkgconfig.modversion("libprecice"))
+    version = pkgconfig.modversion("libprecice")
+    print(f"Found preCICE version {version}")
+    return pkgconfig.cflags("libprecice").split(), pkgconfig.libs("libprecice").split()
+
+
+def get_extensions():
+    cflags, ldflags = find_precice()
 
     compile_args = ["-std=c++17"]
     link_args = []
     include_dirs = [numpy.get_include()]
     bindings_sources = ["cyprecice/cyprecice.pyx"]
-    compile_args += pkgconfig.cflags("libprecice").split()
+    compile_args += cflags
 
     if os.environ.get(MOCKED_ENV) is not None:
         print(f"Building mocked pyprecice as {MOCKED_ENV} is set")
         bindings_sources.append("test/Participant.cpp")
     else:
-        link_args += pkgconfig.libs("libprecice").split()
+        link_args += ldflags
 
     return [
         Extension(


### PR DESCRIPTION
This PR adds a fallback to the setup.py in case preCICE is not found via pkg-config.

The fallback uses no cflags (aka. expect system install) and the `-lprecice` ldflag.

This allows to always build a source distribution of the bindings, which is important for a smooth release process.

A missing preCICE installation will result in a failed wheel build with:

```
$ pyprecice-build -w
...
* Building wheel...
pkg-config was unable to find libprecice.
Please make sure that preCICE was installed correctly and pkg-config is able to find it.
You may need to set PKG_CONFIG_PATH to include the location of the libprecice.pc file.
Use "pkg-config --modversion libprecice" for debugging.
running bdist_wheel
running build
running build_py
copying precice/__init__.py -> build/lib.linux-x86_64-cpython-313/precice
running egg_info
writing pyprecice.egg-info/PKG-INFO
writing dependency_links to pyprecice.egg-info/dependency_links.txt
writing requirements to pyprecice.egg-info/requires.txt
writing top-level names to pyprecice.egg-info/top_level.txt
dependency /tmp/build-env-zypkvg05/lib/python3.13/site-packages/numpy/_core/include/numpy/arrayobject.h won't be automatically included in the manifest: the path must be relative
dependency /tmp/build-env-zypkvg05/lib/python3.13/site-packages/numpy/_core/include/numpy/arrayscalars.h won't be automatically included in the manifest: the path must be relative
dependency /tmp/build-env-zypkvg05/lib/python3.13/site-packages/numpy/_core/include/numpy/ndarrayobject.h won't be automatically included in the manifest: the path must be relative
dependency /tmp/build-env-zypkvg05/lib/python3.13/site-packages/numpy/_core/include/numpy/ndarraytypes.h won't be automatically included in the manifest: the path must be relative
dependency /tmp/build-env-zypkvg05/lib/python3.13/site-packages/numpy/_core/include/numpy/ufuncobject.h won't be automatically included in the manifest: the path must be relative
reading manifest file 'pyprecice.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
adding license file 'LICENSE.txt'
writing manifest file 'pyprecice.egg-info/SOURCES.txt'
running build_ext
building 'cyprecice' extension
x86_64-linux-gnu-g++ -Wall -Wextra -Wno-unused-parameter -fPIC -DNPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION -I/tmp/build-env-zypkvg05/lib/python3.13/site-packages/numpy/_core/include -I/tmp/build-env-zypkvg05/include -I/usr/include/python3.13 -c cyprecice/cyprecice.cpp -o build/temp.linux-x86_64-cpython-313/cyprecice/cyprecice.o -std=c++17
cyprecice/cyprecice.cpp:1199:10: fatal error: precice/precice.hpp: No such file or directory
 1199 | #include "precice/precice.hpp"
      |          ^~~~~~~~~~~~~~~~~~~~~
compilation terminated.
error: command '/usr/bin/x86_64-linux-gnu-g++' failed with exit code 1

ERROR Backend subprocess exited when trying to invoke build_wheel
```