### PR TITLE
Fix passing MPI communicators Participant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## latest
+
+* Fixed passing custom MPI communicators to the Participant https://github.com/precice/python-bindings/pull/256
+
 ## 3.4.0
 
 * Added support for documentation rendering https://github.com/precice/python-bindings/pull/250

--- a/cyprecice/cyprecice.pyx
+++ b/cyprecice/cyprecice.pyx
@@ -9,7 +9,6 @@ cimport cyprecice
 cimport numpy
 import numpy as np
 from mpi4py import MPI
-
 import warnings
 from libcpp.string cimport string
 from libcpp.vector cimport vector

--- a/cyprecice/cyprecice.pyx
+++ b/cyprecice/cyprecice.pyx
@@ -9,6 +9,7 @@ cimport cyprecice
 cimport numpy
 import numpy as np
 from mpi4py import MPI
+
 import warnings
 from libcpp.string cimport string
 from libcpp.vector cimport vector
@@ -63,7 +64,7 @@ cdef class Participant:
             Rank of the process
         solver_process_size : int
             Size of the process
-        communicator: mpi4py.MPI.Intracomm, optional
+        communicator: mpi4py.MPI.Comm, optional
             Custom MPI communicator to use
 
         Returns
@@ -82,10 +83,10 @@ cdef class Participant:
         pass
 
     def __cinit__ (self, solver_name, configuration_file_name, solver_process_index, solver_process_size, communicator=None):
-        cdef void* communicator_ptr
+        cdef size_t c_comm_addr;
         if communicator:
-            communicator_ptr = <void*> communicator
-            self.thisptr = new CppParticipant.Participant (convert(solver_name), convert(configuration_file_name), solver_process_index, solver_process_size, communicator_ptr)
+            c_comm_addr = MPI._addressof(communicator)
+            self.thisptr = new CppParticipant.Participant (convert(solver_name), convert(configuration_file_name), solver_process_index, solver_process_size, <void*>c_comm_addr)
         else:
             self.thisptr = new CppParticipant.Participant (convert(solver_name), convert(configuration_file_name), solver_process_index, solver_process_size)
         pass


### PR DESCRIPTION
This PR fixes passing communicators to the participant initialization.

It used `mpi4py.MPI._addressof` to get the address to the underlying C comm and then forwards that to the participant interface.

Closes #188